### PR TITLE
adds auto-add-to-issues workflow

### DIFF
--- a/.github/workflows/auto-add-issues-to-project.yml
+++ b/.github/workflows/auto-add-issues-to-project.yml
@@ -1,0 +1,20 @@
+name: Adds new Issues automatically to the dGC Project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue or PR to project automatically
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/rcpch/projects/5 #dGC Project
+          github-token: ${{ secrets.AUTO_ADD_TO_PROJECT_TOKEN }}
+


### PR DESCRIPTION
adds just one file, which makes new Issues and PRs get added to the Project automatically, so we can see them in the Kanban view