### PR TITLE
Adds message in the shaded area at term on Weight Centile Chart

### DIFF
--- a/src/CentileChart/CentileChart.tsx
+++ b/src/CentileChart/CentileChart.tsx
@@ -73,9 +73,6 @@ const VictoryZoomVoronoiContainer = createContainer<VictoryZoomContainerProps, V
     'voronoi',
 );
 
-const shadedTermAreaText =
-    'Babies born in this shaded area\nare term. It is normal for\nbabies to lose weight over\nthe first two weeks of life.\nMedical review should be sought\nif weight has dropped by more\nthan 10% of birth weight or\nweight is still below birth weight\nthree weeks after birth.';
-
 function CentileChart({
     chartsVersion,
     reference,
@@ -183,14 +180,12 @@ function CentileChart({
             {
                 x: -0.057494866529774126,
                 y: domains.y[1],
-                y0: domains.y[0],
-                l: shadedTermAreaText,
+                y0: domains.y[0]
             },
             {
                 x: 0.038329911019849415,
                 y: domains.y[1],
-                y0: domains.y[0],
-                l: shadedTermAreaText,
+                y0: domains.y[0]
             },
         ];
     }

--- a/src/functions/tooltips.ts
+++ b/src/functions/tooltips.ts
@@ -85,6 +85,11 @@ export function tooltipText(
             }
         }
         
+        // Term shaded area text
+        if (x < 0.038329911019849415 && x > -0.057494866529774126 && reference ==='uk-who' && measurementMethod === 'weight'){
+            return `${addOrdinalSuffix(l)} centile: \n Babies born in this shaded area\nare term. It is normal for\nbabies to lose weight over\nthe first two weeks of life.\nMedical review should be sought\nif weight has dropped by more\nthan 10% of birth weight or\nweight is still below birth weight\nthree weeks after birth.`;
+        }
+        
         // BMI SDS labels
         if (childName.includes("sdsLine")){
             return `${l} SDS`  


### PR DESCRIPTION
Resolves issue #55 

When hovering over a centile in the shaded term area, a text tooltip appears which explains weight at term.

![image](https://github.com/rcpch/digital-growth-charts-react-component-library/assets/65614251/89e5c12e-cd5e-4311-9a50-21c8e1fe827b)
