### PR TITLE
radiobutton-dynamic-naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rcpch/digital-growth-charts-react-component-library",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
   "main": "build/index.js",
   "module": "build/esm.index.js",

--- a/src/CentileChart/CentileChart.tsx
+++ b/src/CentileChart/CentileChart.tsx
@@ -102,7 +102,8 @@ function CentileChart({
     const [userDomains, setUserDomains] = useState(null);
 
     const [storedChildMeasurements, setStoredChildMeasurements] = useState(childMeasurements)
-    const { defaultShowCorrected, defaultShowChronological, showToggle } = defaultToggles(childMeasurements);
+    const { defaultShowCorrected, defaultShowChronological, showToggle } = { defaultShowCorrected: true, defaultShowChronological: false, showToggle: true };
+    // const { defaultShowCorrected, defaultShowChronological, showToggle } = defaultToggles(childMeasurements);
     const [showChronologicalAge, setShowChronologicalAge] = useState(defaultShowChronological);
     const [showCorrectedAge, setShowCorrectedAge] = useState(defaultShowCorrected);
     const chartRef=useRef<any>();
@@ -221,17 +222,22 @@ function CentileChart({
             case 'unadjusted':
                 setShowChronologicalAge(true);
                 setShowCorrectedAge(false);
+                
                 break;
             case 'adjusted':
-                setShowChronologicalAge(false);
-                setShowCorrectedAge(true);
-                break;
+                    setShowChronologicalAge(false);
+                    setShowCorrectedAge(true);
+                    
+                    break;
             case 'both':
-                setShowChronologicalAge(true);
-                setShowCorrectedAge(true);
+                    setShowChronologicalAge(true);
+                    setShowCorrectedAge(true);
+                   
                 break;
             default:
                 console.warn('Fall through case on toggle adjusted age function');
+
+            
         }
         setUserDomains(null);
     };
@@ -243,7 +249,7 @@ function CentileChart({
     const renderGradientLabels = () => {
         setCentileLabels(!centileLabels);
     }
-    
+
     // always reset zoom to default when measurements array changes
     useLayoutEffect(() => {
         setUserDomains(null);
@@ -297,8 +303,8 @@ function CentileChart({
                                     backgroundPadding={5}
                                     pointerLength={5}
                                     cornerRadius={0}
-                                    flyoutStyle={styles.toolTipFlyout}
-                                    style={styles.toolTipMain}
+                                    flyoutStyle={{...styles.toolTipFlyout}}
+                                    style={{...styles.toolTipMain}}
                                 />
                             }
                             labels={({ datum }) => {
@@ -456,88 +462,90 @@ function CentileChart({
                     {/* Tooltips are found in the parent element (VictoryChart). Tooltips included: */}
                     {/* 1 for each centile, 1 for the shaded area, 1 at 2years to indicate children are measured standing leading */}
                     {/* to a step down in height weight and bmi in the data set. There is another tool tip at 4 years to indicate transition from datasets. */}
+                    
+                        {centileData &&
+                            centileData.map((referenceData, referenceIndex) => {
 
-                    {centileData &&
-                        centileData.map((referenceData, referenceIndex) => {
-
-                            return (
-                                <VictoryGroup
-                                    key={'centileDataBlock' + referenceIndex}
-                                    name='centileLineGroup'
-                                >
-                                    {referenceData.map((centile: ICentile, centileIndex: number) => {
-
-                                        // BMI charts also have SDS lines at -5, -4, -3, -2, 2, 3, 4, 5
-
-                                        if (centile.data.length < 1){
-                                            // prevents a css `width` infinity error if no data presented to centile line
-                                            return
-                                        }
-
+                                return (
+                                    <VictoryGroup
+                                        key={'centileDataBlock' + referenceIndex}
+                                        name='centileLineGroup'
+                                    >
                                         
-                                        if (centileIndex % 2 === 0) {
-                                            // even index - centile is dashed
-                                            return (
-                                                <VictoryLine
-                                                    data-testid={'reference-'+referenceIndex+'-centile-'+centile.centile+'-measurement-'+measurementMethod}
-                                                    name={'centileLine-'+ centileIndex}
-                                                    key={centile.centile + '-' + centileIndex}
-                                                    padding={{ top: 20, bottom: 20 }}
-                                                    data={centile.data}
-                                                    style={styles.dashedCentile}
-                                                    labels={ (props: { index: number; }) => centileLabels && labelIndexInterval(chartScaleType, props.index) && props.index > 0 ? [addOrdinalSuffix(centile.centile)]: null}
-                                                    labelComponent={
-                                                        <VictoryLabel
-                                                            angle={
-                                                                ({index})=>{
-                                                                    return labelAngle(centile.data, index, chartScaleType, measurementMethod, domains);
-                                                                }
+                                        { referenceData.map((centile: ICentile, centileIndex: number) => {
+
+                                            // BMI charts also have SDS lines at -5, -4, -3, -2, 2, 3, 4, 5
+
+                                            if (centile.data.length < 1){
+                                                // prevents a css `width` infinity error if no data presented to centile line
+                                                return
+                                            }
+
+                                            if (centileIndex % 2 === 0) {
+                                                // even index - centile is dashed
+                                                    
+                                                    return (
+                                                        <VictoryLine
+                                                            data-testid={'reference-'+referenceIndex+'-centile-'+centile.centile+'-measurement-'+measurementMethod}
+                                                            name={'centileLine-'+ centileIndex}
+                                                            key={centile.centile + '-' + centileIndex}
+                                                            padding={{ top: 20, bottom: 20 }}
+                                                            data={centile.data}
+                                                            style={{...styles.dashedCentile}}
+                                                            labels={ (props: { index: number; }) => centileLabels && labelIndexInterval(chartScaleType, props.index) && props.index > 0 ? [addOrdinalSuffix(centile.centile)]: null}
+                                                            labelComponent={
+                                                                <VictoryLabel
+                                                                    angle={
+                                                                        ({index})=>{
+                                                                            return labelAngle(centile.data, index, chartScaleType, measurementMethod, domains);
+                                                                        }
+                                                                    }
+                                                                    style={styles.centileLabel}
+                                                                    backgroundStyle={{fill:'white'}}
+                                                                    backgroundPadding={{top: 1, bottom: 1, left: 3, right:3}}
+                                                                    textAnchor={'middle'}
+                                                                    verticalAnchor={'middle'}
+                                                                    dy={0}
+                                                                />
                                                             }
-                                                            style={styles.centileLabel}
-                                                            backgroundStyle={{fill:'white'}}
-                                                            backgroundPadding={{top: 1, bottom: 1, left: 3, right:3}}
-                                                            textAnchor={'middle'}
-                                                            verticalAnchor={'middle'}
-                                                            dy={0}
                                                         />
-                                                    }
-                                                />
-                                            );
-                                        } else {
-                                            // uneven index - centile is continuous
-                                            
-                                            return (
-                                                <VictoryLine
-                                                    data-testid={'reference-'+referenceIndex+'-centile-'+centile.centile+'-measurement-'+measurementMethod}
-                                                    name={'centileLine-'+ centileIndex}
-                                                    key={centile.centile + '-' + centileIndex}
-                                                    padding={{ top: 20, bottom: 20 }}
-                                                    data={centile.data}
-                                                    style={{...styles.continuousCentile}}
-                                                    labels={ (props: { index: number; })=> centileLabels && labelIndexInterval(chartScaleType, props.index) && props.index > 0 ? [addOrdinalSuffix(centile.centile)]: null}
-                                                    labelComponent={
-                                                        <VictoryLabel
-                                                            angle={
-                                                                ({index})=>{
-                                                                    return labelAngle(centile.data, index, chartScaleType, measurementMethod, domains);
+                                                    );
+                                                
+                                            } else{
+                                                // uneven index - centile is continuous
+                                                
+                                                return (
+                                                    <VictoryLine
+                                                        data-testid={'reference-'+referenceIndex+'-centile-'+centile.centile+'-measurement-'+measurementMethod}
+                                                        name={'centileLine-'+ centileIndex}
+                                                        key={centile.centile + '-' + centileIndex}
+                                                        padding={{ top: 20, bottom: 20 }}
+                                                        data={centile.data}
+                                                        style={{...styles.continuousCentile}}
+                                                        labels={ (props: { index: number; })=> centileLabels && labelIndexInterval(chartScaleType, props.index) && props.index > 0 ? [addOrdinalSuffix(centile.centile)]: null}
+                                                        labelComponent={
+                                                            <VictoryLabel
+                                                                angle={
+                                                                    ({index})=>{
+                                                                        return labelAngle(centile.data, index, chartScaleType, measurementMethod, domains);
+                                                                    }
                                                                 }
-                                                            }
-                                                            style={[{ fill: styles.centileLabel.fill, fontFamily: styles.centileLabel.fontFamily, fontSize: styles.centileLabel.fontSize }]}
-                                                            backgroundStyle={{fill:'white'}}
-                                                            backgroundPadding={{top: 0, bottom: 0, left: 3, right:3}}
-                                                            textAnchor={'middle'}
-                                                            verticalAnchor={'middle'}
-                                                            dy={0}
-                                                        />
-                                                    }
-                                                />
-                                            );
-                                        }
-                                    })}
-                                </VictoryGroup>
-                            );
-                        })
-                    }
+                                                                style={[{ fill: styles.centileLabel.fill, fontFamily: styles.centileLabel.fontFamily, fontSize: styles.centileLabel.fontSize }]}
+                                                                backgroundStyle={{fill:'white'}}
+                                                                backgroundPadding={{top: 0, bottom: 0, left: 3, right:3}}
+                                                                textAnchor={'middle'}
+                                                                verticalAnchor={'middle'}
+                                                                dy={0}
+                                                            />
+                                                        }
+                                                    />
+                                                );
+                                            }
+                                        })}
+                                    </VictoryGroup>
+                                );
+                            })
+                        }
 
                     {
                         /* BMI SDS lines */
@@ -556,7 +564,7 @@ function CentileChart({
                                                 // prevents a css `width` infinity error if no data presented to sds line
                                                 return
                                             }
-                                            
+                                                
                                                 // sds line is dashed
                                                 return (
                                                     <VictoryLine
@@ -914,7 +922,7 @@ function CentileChart({
                                 $fontStyle={styles.toggleStyle.fontStyle}
                                 $color={styles.toggleStyle.color}
                                 $className={"toggleButtons"}
-                                handleClick={onSelectRadioButton}
+                                handleClickAgeRadio={onSelectRadioButton}
                                 correctedAge={showCorrectedAge}
                                 chronologicalAge={showChronologicalAge}
                             />

--- a/src/RCPCHChart/RCPCHChart.stories.tsx
+++ b/src/RCPCHChart/RCPCHChart.stories.tsx
@@ -100,7 +100,7 @@ export const PrematureSDSChart: Story = {
     chartType: 'sds',
     enableExport: false,
     exportChartCallback: ()=>{},
-    theme: 'tanner3',
+    theme: 'tanner2',
     customThemeStyles: {}
   },
 };

--- a/src/SDSChart/SDSChart.tsx
+++ b/src/SDSChart/SDSChart.tsx
@@ -597,7 +597,7 @@ const SDSChart: React.FC<SDSChartProps> = (
                             $fontStyle={styles.toggleStyle.fontStyle}
                             $color={styles.toggleStyle.color}
                             $className={"toggleButtons"}
-                            handleClick={onSelectRadioButton}
+                            handleClickAgeRadio={onSelectRadioButton}
                             correctedAge={showCorrectedAge}
                             chronologicalAge={showChronologicalAge}
                         />

--- a/src/SubComponents/AgeRadioButtonGroup.tsx
+++ b/src/SubComponents/AgeRadioButtonGroup.tsx
@@ -1,35 +1,38 @@
 import * as React from 'react';
 
 export const AgeRadioButtonGroup = (props: any) => {
+
+    const uniqueId = Math.random().toString(36);
+
     return (
-        <div onChange={props.handleClick} className={props.className}>
+        <div onChange={props.handleClickAgeRadio} className={props.className}>
             <input
                 data-testid='adjusted'
                 type="radio"
-                id="adjusted"
+                id={`adjusted-${uniqueId}`}
                 value="adjusted"
-                name="adjustments"
+                name={`adjustments${uniqueId}`}
                 defaultChecked={props.correctedAge && props.chronologicalAge === false}
             />
-            <label htmlFor="adjusted">Corrected Age</label>
+            <label htmlFor={`adjusted-${uniqueId}`}>Corrected Age</label>
             <input
                 data-testid='unadjusted'
                 type="radio"
-                id="unadjusted"
+                id={`unadjusted-${uniqueId}`}
                 value="unadjusted"
-                name="adjustments"
+                name={`adjustments${uniqueId}`}
                 defaultChecked={props.chronologicalAge && props.correctedAge === false}
             />
-            <label htmlFor="unadjusted">Chronological Age</label>
+            <label htmlFor={`unadjusted-${uniqueId}`}>Chronological Age</label>
             <input
                 data-testid='both'
                 type="radio"
-                id="both"
+                id={`both-${uniqueId}`}
                 value="both"
-                name="adjustments"
+                name={`adjustments${uniqueId}`}
                 defaultChecked={props.correctedAge === props.chronologicalAge}
             />
-            <label htmlFor="both">Both Ages</label>
+            <label htmlFor={`both-${uniqueId}`}>Both Ages</label>
         </div>
     );
 };

--- a/src/SubComponents/StyledResetZoomButton.tsx
+++ b/src/SubComponents/StyledResetZoomButton.tsx
@@ -14,6 +14,8 @@ export const StyledResetZoomButton = styled.button<{
     align-self: flex-end;
     background-color: ${({$enabled, $activeColour, $inactiveColour}) => ($enabled ? $activeColour : $inactiveColour)};
     border: 2px solid ${({$enabled, $activeColour, $inactiveColour}) => ($enabled ? $activeColour : $inactiveColour)};
+    border-radius: 0px;
+    margin: ${({ $margin }) => $margin};
     font-family: Arial;
     font-size: 14px;
     min-height: 30px;

--- a/src/functions/makeAllStyles.ts
+++ b/src/functions/makeAllStyles.ts
@@ -270,6 +270,7 @@ function makeAllStyles(
             color: chartStyle?.toggleButtonTextStyle?.colour ?? white,
             fontSize: chartStyle?.toggleButtonTextStyle?.size ?? 14,
             fontStyle: chartStyle?.toggleButtonTextStyle?.style === 'italic' ? 'italic' : 'normal',
+            margin: 0
         },
     };
 }

--- a/src/testParameters/styles/tanner2Styles.ts
+++ b/src/testParameters/styles/tanner2Styles.ts
@@ -34,11 +34,11 @@ export const Tanner2ChartStyles: ChartStyle = {
         size: 12,
         style: 'italic'
     },
-    tooltipBackgroundColour: "#fdc300",
-    tooltipStroke: "#fdc300",
+    tooltipBackgroundColour: "#3366cc",
+    tooltipStroke: "##3366cc",
     tooltipTextStyle: {
         name: "Montserrat",
-        colour: "#000000",
+        colour: "#FFFFFF",
         size: 14,
         style: 'normal'
     },
@@ -63,10 +63,10 @@ export const Tanner2GridlineStyles: GridlineStyle = {
 
 export const Tanner2CentileStyles: CentileStyle = {
     sdsStroke: "#A9A9A9",
-    centileStroke: "#7159aa",
-    delayedPubertyAreaFill: "#c6bddd",
+    centileStroke: "#ff8000",
+    delayedPubertyAreaFill: "#ffc080",
     midParentalCentileStroke: "#ff8000",
-    midParentalAreaFill: "#c6bddd",
+    midParentalAreaFill: "#ffc080",
 }
 
 export const Tanner2MeasurementStyles: MeasurementStyle = {
@@ -80,10 +80,10 @@ export const Tanner2MeasurementStyles: MeasurementStyle = {
     }
 }
 export const Tanner2SDSStyles: SDSStyle = {
-    heightStroke: "#ff8000ff",
-    weightStroke: "#ff80007f",
-    ofcStroke: "#ff80003f",
-    bmiStroke: "#ff80001f",
+    heightStroke: "#7159aa",
+    weightStroke: "#ff8000",
+    ofcStroke: "#e60700",
+    bmiStroke: "#c2a712",
 }
 
 /*
@@ -234,28 +234,28 @@ export const Tanner2Styles = {
     },
     "heightSDS": {
         "data": {
-            "stroke": "#ff8000ff",
+            "stroke": "#7159aa",
             "strokeWidth": 1.5,
             "strokeLinecap": "round"
         }
     },
     "weightSDS": {
         "data": {
-            "stroke": "#ff80007f",
+            "stroke": "#ff8000",
             "strokeWidth": 1.5,
             "strokeLinecap": "round"
         }
     },
     "ofcSDS": {
         "data": {
-            "stroke": "#ff80003f",
+            "stroke": "#e60700",
             "strokeWidth": 1.5,
             "strokeLinecap": "round"
         }
     },
     "bmiSDS": {
         "data": {
-            "stroke": "#ff80001f",
+            "stroke": "#c2a712",
             "strokeWidth": 1.5,
             "strokeLinecap": "round"
         }


### PR DESCRIPTION
### Overview
A bug first identified by @dmc-cambric that when two `<RCPCHChart key={'1'} {...props}/> components are rendered side by side, the radiobuttons toggling between chronological/corrected/both ages were clashing - selecting the buttons would update the state and refresh the plot, but would deselect the radio button in the other component.

This was because the `name` attribute in the radiobutton group was clashing in the DOM with the other instance. 

Alongside the fix for this, opportunistically a few small changes were also made.

### Code changes
- `AgeRadioButtonGroup.tsx` introduces a randomly generated string appended to the `id` and the `name` of each radiobutton `input` for the life of the component.
- `StyledResetZoomButton` - passes the `margin` prop through to the component from `makeAllStyles`. sets the border-radius to 0 as button showing as rounded in storybook
- rename the callback from the radiobutton group from `handleClick` (which is used elsewhere) to more meaningful name
- bug fix for tanner2 them which had been duplicated with tanner1 in error. Returns the theme to the orginal tanner2 styles
- `package.json` bumps the version as a patch


### Related Issues
closes #85


### Mentions
Many thanks to @dmc-cambric for picking this up and ongoing support for the project.
