### PR TITLE
Hovering over bone age tooltip causes chart to crash 

### DIFF
--- a/src/functions/tooltips.ts
+++ b/src/functions/tooltips.ts
@@ -160,7 +160,7 @@ export function tooltipText(
                 if (bone_age_type==='bonexpert'){
                     concatenatedText+="\nBoneXpert";
                 }
-                if (bone_age_label.length > 0) {
+                if (bone_age_label && bone_age_label.length > 0) {
                     concatenatedText+="\n"+bone_age_label
                 }
             }


### PR DESCRIPTION
Hi team, 

Have found a bug when rendering a height chart. When a bone age measurement is present but has a 'null' value comment, the chart throws the following error:

I've fixed this temporarily in our implementation by sending an empty string value to the 'bone_age_text' param of the API. 


File: src\functions\tooltips.ts
Proposed fix: check bone_age_label is not null before checking length property. 


The error: 
![image](https://github.com/user-attachments/assets/7943693f-f25d-463c-a79b-fc3202b15f51)

Before hovering over bone age:
![image](https://github.com/user-attachments/assets/dc8ad286-172c-4956-bc08-5e84191c76bf)

After hovering over bone age: 
![image](https://github.com/user-attachments/assets/3adc2386-6231-4d00-a06f-de1c795c4aa0)
