### PR TITLE
increase-measurement-pointsize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rcpch/digital-growth-charts-react-component-library",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
   "main": "build/index.js",
   "module": "build/esm.index.js",

--- a/src/CentileChart/CentileChart.tsx
+++ b/src/CentileChart/CentileChart.tsx
@@ -681,8 +681,8 @@ function CentileChart({
                             chronData.size = 1.5;
                             correctData.size = 1.5;
                         } else {
-                            chronData.size = 3;
-                            correctData.size = 3;
+                            chronData.size = 3.5;
+                            correctData.size = 3.5;
                         }
 
                         return (

--- a/src/testParameters/styles/tanner2Styles.ts
+++ b/src/testParameters/styles/tanner2Styles.ts
@@ -285,7 +285,7 @@ export const Tanner2Styles = {
     },
     "measurementPoint": {
         "data": {
-            "fill": "#000000"
+            "fill": "#000000",
         }
     },
     "measurementLinkLine": {


### PR DESCRIPTION
### Overview
observation the in v7.0.0 the plotted points appear smaller.

### Code changes
Measurement points are dynamically sized and this code has not changed since v.6 so it is not clear why they look smaller now. I have increased the default size of chronological and corrected plots to 3.5pt though this reduces to 1.5 if points are crowded.

There is no user prop for this and I am inclined to keep this definition as a core chart style. 

### Related Issues
closes #94

### Mentions
@dmc-cambric
