### PR TITLE
trisomy-21-bmi-rendering-issue-fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rcpch/digital-growth-charts-react-component-library",
-  "version": "7.0.6",
+  "version": "7.0.8",
   "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
   "main": "build/index.js",
   "module": "build/esm.index.js",

--- a/src/CentileChart/CentileChart.stories.tsx
+++ b/src/CentileChart/CentileChart.stories.tsx
@@ -26,6 +26,7 @@ import { termToOverFourYearsGirlHeight } from '../testParameters/measurements/te
 import { turnerHeightOneYearToEleven } from '../testParameters/measurements/turnerHeightOneYearToEleven';
 import { beforeDueDateError } from '../testParameters/measurements/beforeDueDateError';
 import { termBabyGirlWeight } from '../testParameters/measurements/termBabyGirlWeight';
+import { trisomy21HighBMI } from '../testParameters/measurements/trisomy21HighBMI';
 
 export default {
     title: 'CentileChart',
@@ -454,6 +455,24 @@ export const WithTermBabyGirlWeight = () => (
         measurementMethod="weight"
         sex="female"
         childMeasurements={termBabyGirlWeight}
+        midParentalHeightData={midParentalHeights}
+        enableZoom={true}
+        styles={Tanner3Styles}
+        enableExport={true}
+        exportChartCallback={() => null}
+        clinicianFocus={true}
+    />
+);
+
+export const WithTrisomy21HighBMI = () => (
+    <CentileChart
+        chartsVersion="7.0.0"
+        reference="trisomy-21"
+        title="Trisomy 21 Child"
+        subtitle="High BMI Boy"
+        measurementMethod="bmi"
+        sex="male"
+        childMeasurements={trisomy21HighBMI}
         midParentalHeightData={midParentalHeights}
         enableZoom={true}
         styles={Tanner3Styles}

--- a/src/chartdata/reference-data.d.ts
+++ b/src/chartdata/reference-data.d.ts
@@ -51,7 +51,7 @@ export { ukwhoBMIFemaleCentileData }
 export { ukwhoBMIMaleSDSData }
 export { ukwhoBMIFemaleSDSData }
 
-export { ukwhoCustomData }
+// export { ukwhoCustomData }
 
 export { trisomy21HeightMaleCentileData }
 export { trisomy21HeightFemaleCentileData }

--- a/src/functions/getDomainsAndData.ts
+++ b/src/functions/getDomainsAndData.ts
@@ -351,6 +351,7 @@ function updateCoordsOfExtremeValues(
     d: IPlottedCentileMeasurement,
     native = false,
 ): void {
+    
     // transition points can lead to inaccurate coords for centile labels, therefore don't include 2 or 4 years old
     if (!native || (d.x !== 4 && d.x !== 2)) {
         if (extremeValues.lowestY > d.y) {
@@ -358,6 +359,11 @@ function updateCoordsOfExtremeValues(
         }
 
         if (extremeValues.highestY < d.y) {
+            extremeValues.highestY = d.y;
+        }
+        // this is necessary because in the BMI dataset (esp Trisomy-21), the values for Y ramp up to infinitity towards the end of the dataset
+        // this is a hack to prevent the chart from scaling to infinity - see discussion in #93 about the nature of SDS calculation when L is 0 or negative
+        if (extremeValues.highestY > 500){
             extremeValues.highestY = d.y;
         }
 

--- a/src/functions/getDomainsAndData.ts
+++ b/src/functions/getDomainsAndData.ts
@@ -31,6 +31,7 @@ import { trisomy21WeightFemaleCentileData } from '../chartdata/trisomy21_weight_
 import { trisomy21OFCMaleCentileData } from '../chartdata/trisomy21_ofc_male_centile_data';
 import { trisomy21OFCFemaleCentileData } from '../chartdata/trisomy21_ofc_female_centile_data';
 import { turnerHeightFemaleCentileData } from '../chartdata/turner_height_female_centile_data';
+import { LineSegment } from 'victory';
 
 type CentileLabelValues = {
     0.4: { value: number; workingX: number };
@@ -302,7 +303,7 @@ function childMeasurementRanges(
             console.warn('Measurements considered invalid by the API given to the chart. The chart will ignore them.');
         }
     }
-    
+
     return { lowestChildX, highestChildX, lowestChildY, highestChildY };
 }
 

--- a/src/functions/tooltips.ts
+++ b/src/functions/tooltips.ts
@@ -40,6 +40,11 @@ export function tooltipText(
         chronological_percentage_median_bmi
     } = datum;
 
+    if (datum.y === null) {
+        return
+    }
+    
+
     // flag passed in from user - if clinician, show clinician age advice strings, else show child/family advice 
     const comment = clinicianFocus ? clinician_comment : lay_comment;
 

--- a/src/testParameters/measurements/trisomy21HighBMI.ts
+++ b/src/testParameters/measurements/trisomy21HighBMI.ts
@@ -1,0 +1,148 @@
+import type { Measurement } from "../../interfaces/RCPCHMeasurementObject";
+
+export const trisomy21HighBMI: Measurement[] = [
+    {
+        "birth_data": {
+            "birth_date": "2006-05-08",
+            "gestation_weeks": 40,
+            "gestation_days": 0,
+            "estimated_date_delivery": "2006-05-08",
+            "estimated_date_delivery_string": "Mon 08 May, 2006",
+            "sex": "male"
+        },
+        "measurement_dates": {
+            "observation_date": "2022-11-01",
+            "chronological_decimal_age": 16.484599589322382,
+            "corrected_decimal_age": 16.484599589322382,
+            "chronological_calendar_age": "16 years, 5 months, 3 weeks and 3 days",
+            "corrected_calendar_age": "16 years, 5 months, 3 weeks and 3 days",
+            "corrected_gestational_age": {
+                "corrected_gestation_weeks": null,
+                "corrected_gestation_days": null
+            },
+            "comments": {
+                "clinician_corrected_decimal_age_comment": "Born at term. No correction has been made for gestation.",
+                "lay_corrected_decimal_age_comment": "Your child was born on their due date.",
+                "clinician_chronological_decimal_age_comment": "Born Term. No correction has been made for gestation.",
+                "lay_chronological_decimal_age_comment": "Your child was born on their due date."
+            },
+            "corrected_decimal_age_error": null,
+            "chronological_decimal_age_error": null
+        },
+        "child_observation_value": {
+            "measurement_method": "bmi",
+            "observation_value": 36.3,
+            "observation_value_error": null
+        },
+        "measurement_calculated_values": {
+            "corrected_sds": 1.9929195642473767,
+            "corrected_centile": 97.7,
+            "corrected_centile_band": "This body mass index measurement is on or near the 98th centile.",
+            "chronological_sds": 1.9929195642473767,
+            "chronological_centile": 97.7,
+            "chronological_centile_band": "This body mass index measurement is on or near the 98th centile.",
+            "corrected_measurement_error": null,
+            "chronological_measurement_error": null,
+            "corrected_percentage_median_bmi": 163.3208998549931,
+            "chronological_percentage_median_bmi": 163.3208998549931
+        },
+        "plottable_data": {
+            "centile_data": {
+                "chronological_decimal_age_data": {
+                    "x": 16.484599589322382,
+                    "y": 36.3,
+                    "b": null,
+                    "centile": 97.7,
+                    "sds": 1.9929195642473767,
+                    "bone_age_label": null,
+                    "events_text": null,
+                    "bone_age_type": null,
+                    "bone_age_sds": null,
+                    "bone_age_centile": null,
+                    "observation_error": null,
+                    "age_type": "chronological_age",
+                    "calendar_age": "16 years, 5 months, 3 weeks and 3 days",
+                    "lay_comment": "Your child was born on their due date.",
+                    "clinician_comment": "Born Term. No correction has been made for gestation.",
+                    "age_error": null,
+                    "centile_band": "This body mass index measurement is on or near the 98th centile.",
+                    "observation_value_error": null
+                },
+                "corrected_decimal_age_data": {
+                    "x": 16.484599589322382,
+                    "y": 36.3,
+                    "b": null,
+                    "centile": 97.7,
+                    "sds": 1.9929195642473767,
+                    "bone_age_label": null,
+                    "events_text": null,
+                    "bone_age_type": null,
+                    "bone_age_sds": null,
+                    "bone_age_centile": null,
+                    "observation_error": null,
+                    "age_type": "corrected_age",
+                    "calendar_age": "16 years, 5 months, 3 weeks and 3 days",
+                    "corrected_gestational_age": "",
+                    "lay_comment": "Your child was born on their due date.",
+                    "clinician_comment": "Born at term. No correction has been made for gestation.",
+                    "age_error": null,
+                    "centile_band": "This body mass index measurement is on or near the 98th centile.",
+                    "observation_value_error": null
+                }
+            },
+            "sds_data": {
+                "chronological_decimal_age_data": {
+                    "x": 16.484599589322382,
+                    "y": 1.9929195642473767,
+                    "b": null,
+                    "centile": 97.7,
+                    "sds": null,
+                    "bone_age_label": null,
+                    "events_text": null,
+                    "bone_age_type": null,
+                    "bone_age_sds": null,
+                    "bone_age_centile": null,
+                    "observation_error": null,
+                    "age_type": "chronological_age",
+                    "calendar_age": "16 years, 5 months, 3 weeks and 3 days",
+                    "lay_comment": "Your child was born on their due date.",
+                    "clinician_comment": "Born Term. No correction has been made for gestation.",
+                    "age_error": null,
+                    "centile_band": "This body mass index measurement is on or near the 98th centile.",
+                    "observation_value_error": null
+                },
+                "corrected_decimal_age_data": {
+                    "x": 16.484599589322382,
+                    "y": 1.9929195642473767,
+                    "b": null,
+                    "centile": 97.7,
+                    "sds": null,
+                    "bone_age_label": null,
+                    "events_text": null,
+                    "bone_age_type": null,
+                    "bone_age_sds": null,
+                    "bone_age_centile": null,
+                    "observation_error": null,
+                    "age_type": "corrected_age",
+                    "calendar_age": "16 years, 5 months, 3 weeks and 3 days",
+                    "corrected_gestational_age": "",
+                    "lay_comment": "Your child was born on their due date.",
+                    "clinician_comment": "Born at term. No correction has been made for gestation.",
+                    "age_error": null,
+                    "centile_band": "This body mass index measurement is on or near the 98th centile.",
+                    "observation_value_error": null
+                }
+            }
+        },
+        "bone_age": {
+            "bone_age": null,
+            "bone_age_type": null,
+            "bone_age_sds": null,
+            "bone_age_centile": null,
+            "bone_age_text": null
+        },
+        "events_data": {
+            "events_text": null
+        }
+    }
+]


### PR DESCRIPTION
### Overview
Bug identified by @princepsivannhs where the BMI dataset for Trisomy-21 contains values that run into the thousands. This is function of the LMS calculation such that when the value of L is negative (see discussion in the issue #93), z rapidly rises to infinity.

To overcome this, visible data is filtered exclude higher values of y before plotting.

### Code changes
`getDomainsAndData.ts` includes  a conditional to filter out values > 500.

### Documentation changes (done or required as a result of this PR)
See issue #93 for discussion

### Related Issues
Closes #93

### Mentions
Thank you to @princepsivannhs for identifying, @statist7 for clarifying the maths and @mbarton to debugging and creating a new story.
