### PR TITLE
Fix-reopened-measurement-plot-size-issue-94

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rcpch/digital-growth-charts-react-component-library",
-  "version": "7.0.7",
+  "version": "7.0.9",
   "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
   "main": "build/index.js",
   "module": "build/esm.index.js",

--- a/src/CentileChart/CentileChart.tsx
+++ b/src/CentileChart/CentileChart.tsx
@@ -678,11 +678,11 @@ function CentileChart({
                         };
 
                         if (isChartCrowded) {
-                            chronData.size = 1.5;
-                            correctData.size = 1.5;
-                        } else {
                             chronData.size = 3.5;
                             correctData.size = 3.5;
+                        } else {
+                            chronData.size = 4.5;
+                            correctData.size = 4.5;
                         }
 
                         return (

--- a/src/functions/makeAllStyles.ts
+++ b/src/functions/makeAllStyles.ts
@@ -15,7 +15,7 @@ This function therefore instantiates defaults where user values have not been pr
 This creates a styles object that is passed to the chart.
 */
 import { AxisStyle, CentileStyle, SDSStyle, ChartStyle, GridlineStyle, MeasurementStyle } from '../interfaces/StyleObjects';
-import { setOpacity } from './setOpacity';
+import montserratRegular from '../fonts/Montserrat/Montserrat-Regular.ttf';
 
 const black = '#000000';
 const white = '#FFFFFF';
@@ -67,7 +67,7 @@ function makeAllStyles(
         toolTipMain: {
             fontSize: chartStyle?.tooltipTextStyle?.size ?? 14,
             fill: chartStyle?.tooltipTextStyle?.colour ?? black,
-            fontFamily: chartStyle?.tooltipTextStyle?.name ?? 'Montserrat',
+            fontFamily: chartStyle?.tooltipTextStyle?.name ?? montserratRegular,
             fontStyle: chartStyle?.tooltipTextStyle?.style ?? 'normal',
             textAnchor: "start"
         },
@@ -187,7 +187,7 @@ function makeAllStyles(
         },
         centileLabel: {
             fontSize: 6,
-            fontFamily: 'Montserrat',
+            fontFamily: montserratRegular,
             fill: centileStyle?.centileStroke ?? black
         },
         heightSDS: {
@@ -241,7 +241,7 @@ function makeAllStyles(
                 opacity: 0.5
             }
         },
-        measurementPoint: {
+        measurementPoint: { // these are the points on the chart where measurements are plotted: note that the size is dynamically set based on the isCrowded function
             data: {
                 fill: measurementStyle?.measurementFill ?? black,
             },
@@ -252,14 +252,14 @@ function makeAllStyles(
                 strokeWidth: 1.25,
             },
         },
-        highlightedMeasurementFill: {
+        highlightedMeasurementFill: { // these are the points on the chart where measurements are plotted: note that the size is dynamically set based on the isCrowded function
             data: {
-                fill: measurementStyle?.highlightedMeasurementFill ?? black
+                fill: measurementStyle?.highlightedMeasurementFill ?? black,
             }
         },
         eventTextStyle: {
             size: measurementStyle?.eventTextStyle?.size ?? 14,
-            name: measurementStyle?.eventTextStyle?.name ?? 'Montserrat',
+            name: measurementStyle?.eventTextStyle?.name ?? montserratRegular,
             colour: measurementStyle?.eventTextStyle?.colour ?? black,
             style: measurementStyle?.eventTextStyle?.style ?? 'normal'
         },

--- a/src/functions/makeAllStyles.ts
+++ b/src/functions/makeAllStyles.ts
@@ -15,7 +15,6 @@ This function therefore instantiates defaults where user values have not been pr
 This creates a styles object that is passed to the chart.
 */
 import { AxisStyle, CentileStyle, SDSStyle, ChartStyle, GridlineStyle, MeasurementStyle } from '../interfaces/StyleObjects';
-import montserratRegular from '../fonts/Montserrat/Montserrat-Regular.ttf';
 
 const black = '#000000';
 const white = '#FFFFFF';
@@ -67,7 +66,7 @@ function makeAllStyles(
         toolTipMain: {
             fontSize: chartStyle?.tooltipTextStyle?.size ?? 14,
             fill: chartStyle?.tooltipTextStyle?.colour ?? black,
-            fontFamily: chartStyle?.tooltipTextStyle?.name ?? montserratRegular,
+            fontFamily: chartStyle?.tooltipTextStyle?.name ?? 'Montserrat',
             fontStyle: chartStyle?.tooltipTextStyle?.style ?? 'normal',
             textAnchor: "start"
         },
@@ -187,7 +186,7 @@ function makeAllStyles(
         },
         centileLabel: {
             fontSize: 6,
-            fontFamily: montserratRegular,
+            fontFamily: 'Montserrat',
             fill: centileStyle?.centileStroke ?? black
         },
         heightSDS: {
@@ -259,7 +258,7 @@ function makeAllStyles(
         },
         eventTextStyle: {
             size: measurementStyle?.eventTextStyle?.size ?? 14,
-            name: measurementStyle?.eventTextStyle?.name ?? montserratRegular,
+            name: measurementStyle?.eventTextStyle?.name ?? 'Montserrat',
             colour: measurementStyle?.eventTextStyle?.colour ?? black,
             style: measurementStyle?.eventTextStyle?.style ?? 'normal'
         },

--- a/src/functions/stylesForTheme.ts
+++ b/src/functions/stylesForTheme.ts
@@ -5,7 +5,6 @@ import { Tanner3AxisStyles, Tanner3ChartStyles, Tanner3GridlineStyles, Tanner3Ce
 import { traditionalBoyAxisStyles, traditionalBoyChartStyles, traditionalBoyGridlineStyles, traditionalBoyCentileStyles, traditionalBoyMeasurementStyles, traditionalBoySDSStyles } from '../testParameters/styles/traditionalBoysStyles';
 import { traditionalGirlAxisStyles, traditionalGirlChartStyles, traditionalGirlGridlineStyles, traditionalGirlCentileStyles, traditionalGirlMeasurementStyles, traditionalGirlSDSStyles } from '../testParameters/styles/traditionalGirlsStyles';
 import { ChartStyle, AxisStyle, GridlineStyle, CentileStyle, SDSStyle, MeasurementStyle } from '../interfaces/StyleObjects';
-import { Exception } from 'sass';
 
 export const stylesForTheme = (theme: 'monochrome' | 'traditional' | 'tanner1' | 'tanner2' | 'tanner3' | 'custom', sex: 'male' | 'female')=>{
     // Returns the styles objects for a theme. If custom is selected, monochrome is selected to be customized later


### PR DESCRIPTION
### Overview
Solution for #94
FIxes the default size of the measurement points.
Also refactors styles to have montserrat as a string.

### Code changes
Increases both the default size and the size when crowded. Currently though that if only some measurements are crowded, the size change applies to all. Hopefully this will matter less now that they are all much bigger.
