### PR TITLE
tooltips-on-safari-bone-age-cropping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rcpch/digital-growth-charts-react-component-library",
-  "version": "7.0.10",
+  "version": "7.0.11",
   "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
   "main": "dist/index.js",
   "module": "dist/esm.index.js",

--- a/src/CentileChart/CentileChart.tsx
+++ b/src/CentileChart/CentileChart.tsx
@@ -312,6 +312,10 @@ function CentileChart({
                                     backgroundPadding={5}
                                     pointerLength={5}
                                     cornerRadius={0}
+                                    flyoutHeight={(datum) => {
+                                        const numberOfLines = datum.text.length;
+                                        return numberOfLines * 18;    // 18 is the line height
+                                    }}
                                     flyoutStyle={{
                                         ...styles.toolTipFlyout,
                                     }}

--- a/src/CentileChart/CentileChart.tsx
+++ b/src/CentileChart/CentileChart.tsx
@@ -289,6 +289,22 @@ function CentileChart({
                             allowPan={allowZooming}
                             onZoomDomainChange={handleZoomChange}
                             zoomDomain={domains}
+                            labels={({ datum }) => {
+                                // This the tool tip text, and accepts a large number of arguments
+                                // tool tips return contextual information for each datapoint, as well as the centile
+                                // and SDS lines, as well as bone ages, events and midparental heights
+                                const tooltipTextList = tooltipText(
+                                    reference,
+                                    measurementMethod,
+                                    datum,
+                                    midParentalHeightData,
+                                    clinicianFocus,
+                                    sex
+                                )
+                                if (tooltipTextList){
+                                    return tooltipTextList.join('\n').replace(/^\s+|\s+$/g, '');
+                                } 
+                            }}
                             labelComponent={
                                 <VictoryTooltip
                                     data-testid='tooltip'
@@ -301,20 +317,6 @@ function CentileChart({
                                     }}
                                     style={{...styles.toolTipMain}}
                                 />
-                            }
-                            labels={({ datum }) => {
-                                // This the tool tip text, and accepts a large number of arguments
-                                // tool tips return contextual information for each datapoint, as well as the centile
-                                // and SDS lines, as well as bone ages, events and midparental heights
-                                    return tooltipText(
-                                        reference,
-                                        measurementMethod,
-                                        datum,
-                                        midParentalHeightData,
-                                        clinicianFocus,
-                                        sex
-                                    )
-                                }
                             }
                             voronoiBlacklist={['linkLine', 'chronologicalboneagelinkline', 'correctedboneagelinkline', 'areaMPH']}
                         />
@@ -688,7 +690,6 @@ function CentileChart({
                                         
                                         showChronologicalAge && !showCorrectedAge ?
                                         // Events against chronological age only if corrected age not showing
-                                        <VictoryPortal>
                                             <VictoryScatter
                                                 key={"item-"+index}
                                                 name="eventcaret"
@@ -700,10 +701,9 @@ function CentileChart({
                                                     />
                                                 }
                                             />
-                                        </VictoryPortal>
                                         :
                                         // Events against corrected age
-                                        <VictoryPortal>
+                                        
                                             <VictoryScatter
                                                 key={"item-"+index}
                                                 name="eventcaret"
@@ -715,7 +715,7 @@ function CentileChart({
                                                     />
                                                 }
                                             />
-                                        </VictoryPortal>
+                                        
                                     )
                                 }
 

--- a/src/functions/getDomainsAndData.ts
+++ b/src/functions/getDomainsAndData.ts
@@ -21,7 +21,6 @@ import { Domains, IDomainSex } from '../interfaces/Domains';
 
 import { IPlottedCentileMeasurement, Reference, ICentile } from '../interfaces/CentilesObject';
 import deepCopy from './deepCopy';
-import { ClientMeasurementObject } from '../interfaces/ClientMeasurementObject';
 import { trisomy21HeightMaleCentileData } from '../chartdata/trisomy21_height_male_centile_data';
 import { trisomy21HeightFemaleCentileData } from '../chartdata/trisomy21_height_female_centile_data';
 import { trisomy21BMIFemaleCentileData } from '../chartdata/trisomy21_bmi_female_centile_data';
@@ -31,7 +30,6 @@ import { trisomy21WeightFemaleCentileData } from '../chartdata/trisomy21_weight_
 import { trisomy21OFCMaleCentileData } from '../chartdata/trisomy21_ofc_male_centile_data';
 import { trisomy21OFCFemaleCentileData } from '../chartdata/trisomy21_ofc_female_centile_data';
 import { turnerHeightFemaleCentileData } from '../chartdata/turner_height_female_centile_data';
-import { LineSegment } from 'victory';
 
 type CentileLabelValues = {
     0.4: { value: number; workingX: number };
@@ -267,11 +265,8 @@ function childMeasurementRanges(
         let chronologicalX = measurement.plottable_data.centile_data.chronological_decimal_age_data.x;
         let correctedY = measurement.plottable_data.centile_data.corrected_decimal_age_data.y;
         let chronologicalY = measurement.plottable_data.centile_data.chronological_decimal_age_data.y;
+        const boneAgeX = measurement.bone_age.bone_age;
         const errorsPresent = false;
-            // measurement.measurement_calculated_values.corrected_measurement_error ||
-            // measurement.measurement_calculated_values.chronological_measurement_error
-            //     ? true
-            //     : false;
         
         if (!errorsPresent) {
             if (showCorrected && !showChronological) {
@@ -297,6 +292,15 @@ function childMeasurementRanges(
                 }
                 if (lowestChildY > coord) {
                     lowestChildY = coord;
+                }
+            }
+            // if bone age is present and value is more extreme than the highest or lowest x, update:
+            if (boneAgeX) {
+                if (highestChildX < boneAgeX) {
+                    highestChildX = boneAgeX;
+                }
+                if (lowestChildX > boneAgeX) {
+                    lowestChildX = boneAgeX;
                 }
             }
         } else {
@@ -596,6 +600,7 @@ function getDomainsAndData(
         }
         if (errorFree) {
             const { lowestChildX, highestChildX, lowestChildY, highestChildY } = childCoordinates;
+            
             lowestYFromMeasurements = lowestChildY;
             highestYFromMeasurements = highestChildY;
             const difference = highestChildX - lowestChildX;

--- a/src/functions/tooltips.ts
+++ b/src/functions/tooltips.ts
@@ -64,12 +64,13 @@ export function tooltipText(
             corrected_gestational_age=`${gestational_age.corrected_gestation_weeks}+${gestational_age.corrected_gestation_days} weeks`
             returnStringList.push(`${calendar_age}\nCorrected age: ${corrected_gestational_age} on ${observation_date}`)
             returnStringList.push(`${comment}`)
-            returnStringList.push(`${y}${measurementSuffix(measurementMethod)}`)
+            returnStringList.push(`${y} ${measurementSuffix(measurementMethod)}`)
             returnStringList.push(`${corrected_measurement_error}`)
         }
         returnStringList.push(`Corrected age: ${calendar_age} on ${observation_date}`)
         returnStringList.push(`${comment}`)
-        returnStringList.push(`${y} ${measurementSuffix(measurementMethod)} ${corrected_measurement_error}`)
+        returnStringList.push(`${y} ${measurementSuffix(measurementMethod)}`)
+        returnStringList.push(`${corrected_measurement_error}`)
         return returnStringList;
     }
 
@@ -155,7 +156,7 @@ export function tooltipText(
         // Term shaded area text
         if (x < 0.038329911019849415 && x > -0.057494866529774126 && reference ==='uk-who' && measurementMethod === 'weight'){
             let returnStringList = [];
-            returnStringList.push(`${addOrdinalSuffix(l)} centile:`);
+            // returnStringList.push(`${addOrdinalSuffix(l)} centile:`);
             returnStringList.push('Babies born in this shaded area');
             returnStringList.push('are term. It is normal for');
             returnStringList.push('babies to lose weight over');
@@ -192,13 +193,13 @@ export function tooltipText(
         // bone age text
         if ((childName==="chronologicalboneage" || childName === "correctedboneage") && b){
             let returnStringList = [];
-            returnStringList.push( "Bone Age: ${b.toString()} yrs")
+            returnStringList.push( `Bone Age: ${b.toString()} yrs`)
             
             if (bone_age_sds && !isNaN(bone_age_sds)) {
-                returnStringList.push("SDS: ${bone_age_sds.toString()}");
+                returnStringList.push(`SDS: ${bone_age_sds.toString()}`);
             }
             if (bone_age_centile && !isNaN(bone_age_centile)) {
-                returnStringList.push("Centile: ${bone_age_centile.toString()}");
+                returnStringList.push(`Centile: ${bone_age_centile.toString()}`);
             }
             if (bone_age_type && bone_age_type.length > 0) {
                 if (bone_age_type==="greulich-pyle"){
@@ -264,15 +265,15 @@ export function tooltipText(
                 const sds_string = `[SDS: ${sds > 0 ? '+' + Math.round(sds*1000)/1000 : Math.round(sds*1000)/1000 }]`;
                 if (age_type === 'corrected_age') {
                     returnStringList.push(`Corrected age: ${calendar_age} on ${formatted_observation_date} on ${formatted_observation_date}`)
-                    returnStringList.push(`${comment} ${y}`)
-                    returnStringList.push(`${measurementSuffix(measurementMethod)}`);
+                    returnStringList.push(`${comment}`)
+                    returnStringList.push(`${y} ${measurementSuffix(measurementMethod)}`);
                     returnStringList.push(`${ clinicianFocus ? sds_string : finalCentile}`);
                     return returnStringList;
                 }
                 if (age_type === 'chronological_age') {
                     returnStringList.push(`Chronological age: ${calendar_age} on ${formatted_observation_date}`)
-                    returnStringList.push(`${comment} ${y}`)
-                    returnStringList.push(`${measurementSuffix(measurementMethod)}`);
+                    returnStringList.push(`${comment}`)
+                    returnStringList.push(`${y} ${measurementSuffix(measurementMethod)}`);
                     returnStringList.push(`${ clinicianFocus ? sds_string : finalCentile}`);
                     return returnStringList;
                 }

--- a/src/functions/tooltips.ts
+++ b/src/functions/tooltips.ts
@@ -10,7 +10,11 @@ export function tooltipText(
     midParentalHeightData: MidParentalHeightObject,
     clinicianFocus: boolean, // flag passed in from user - defines if tooltip text aimed at clinicians or families
     sex: 'male' | 'female'
-): string {
+): string[]  {
+    /*
+    This function returns an array of strings that represent the tooltip text for a given data point.
+    The strings in each array represent a new line in the tooltip.
+    */
 
     const { 
         childName,
@@ -44,22 +48,29 @@ export function tooltipText(
         return
     }
     
+    let returnStringList = [];
 
     // flag passed in from user - if clinician, show clinician age advice strings, else show child/family advice 
     const comment = clinicianFocus ? clinician_comment : lay_comment;
 
     if (corrected_decimal_age_error && age_type === 'corrected_age'){
-        return corrected_decimal_age_error
+        returnStringList.push(`${corrected_decimal_age_error}`);
+        return returnStringList;
+        // return corrected_decimal_age_error
     }
     if (corrected_measurement_error && age_type === 'corrected_age'){
         let corrected_gestational_age=''
         if (gestational_age){
-            const finalCorrectedString = comment.replaceAll(', ', ',\n').replaceAll('. ', '.\n');
             corrected_gestational_age=`${gestational_age.corrected_gestation_weeks}+${gestational_age.corrected_gestation_days} weeks`
-            return `${calendar_age}\nCorrected age: ${corrected_gestational_age} on ${observation_date}\n${finalCorrectedString}\n${y}${measurementSuffix(measurementMethod)}\n${corrected_measurement_error}`;
+            returnStringList.push(`${calendar_age}\nCorrected age: ${corrected_gestational_age} on ${observation_date}`)
+            returnStringList.push(`${comment}`)
+            returnStringList.push(`${y}${measurementSuffix(measurementMethod)}`)
+            returnStringList.push(`${corrected_measurement_error}`)
         }
-        const finalCorrectedString = comment.replaceAll(', ', ',\n').replaceAll('. ', '.\n');
-        return `Corrected age: ${calendar_age} on ${observation_date}\n${finalCorrectedString}\n${y} ${measurementSuffix(measurementMethod)} ${corrected_measurement_error}`;
+        returnStringList.push(`Corrected age: ${calendar_age} on ${observation_date}`)
+        returnStringList.push(`${comment}`)
+        returnStringList.push(`${y} ${measurementSuffix(measurementMethod)} ${corrected_measurement_error}`)
+        return returnStringList;
     }
 
     // midparental height labels
@@ -72,14 +83,20 @@ export function tooltipText(
         } = midParentalHeightData;
     
         if (['centileMPH', 'lowerCentileMPH', 'upperCentileMPH', 'areaMPH'].includes(childName) && datum._voronoiX < 20){
+            let returnStringList = [];
             if (childName==="lowerCentileMPH"){
-                return `Midparental Height -2SD: ${Math.round(mid_parental_height_lower_value*10)/10} cm`;
+                returnStringList.push(`Midparental Height -2SD: ${Math.round(mid_parental_height_lower_value*10)/10} cm`);
+                return returnStringList;
             }
             if (childName==="centileMPH" || childName==="areaMPH"){
-                return `Midparental Height: ${Math.round(mid_parental_height*10)/10} cm (${addOrdinalSuffix(Math.round(parseFloat(l)))} centile, SDS: ${Math.round(mid_parental_height_sds*100)/100})\nRange(+/-2SD): ${Math.round(mid_parental_height_lower_value*10)/10} cm - ${Math.round(mid_parental_height_upper_value*10)/10} cm`;
+                returnStringList.push(`Midparental Height: ${Math.round(mid_parental_height*10)/10} cm (${addOrdinalSuffix(Math.round(parseFloat(l)))}) centile, SDS: ${Math.round(mid_parental_height_sds*100)/100})`)
+                returnStringList.push(`Range(+/-2SD): ${Math.round(mid_parental_height_lower_value*10)/10} cm - ${Math.round(mid_parental_height_upper_value*10)/10} cm`);
+                
+                return returnStringList;
             }
             if (childName==="upperCentileMPH"){
-                return `Midparental Height +2SD: ${Math.round(mid_parental_height_upper_value*10)/10} cm`;
+                returnStringList.push(`Midparental Height +2SD: ${Math.round(mid_parental_height_upper_value*10)/10} cm`);
+                return returnStringList;
             }
             return;
         }
@@ -88,39 +105,67 @@ export function tooltipText(
 
     // l represent labels that represent reference transitions, puberty area or sds labels for the BMI SDS lines
     if (l) {
-        
+        let returnStringList = [];
         // reference transit point or puberty shaded area labels
         if (x === 0.0383 && reference === 'uk-who') {
-            return 'Transit point from\nUK90 to WHO data';
+            returnStringList.push();
+            returnStringList.push('UK90 to WHO data');
+            return returnStringList;
         }
         if (x === 4 && reference == 'uk-who') {
-            return 'Transit point from\nUK-WHO to UK90 data.';
+            returnStringList.push('Transit point from');
+            returnStringList.push('UK90 to WHO data');
+            return returnStringList;
         }
         if (x === 2 && measurementMethod === 'height' && reference == 'uk-who') {
             // step down at 2 y where children measured standing (height), not lying (length)
-            return "Measure length until age 2y;\nMeasure height after age 2y.\nA child’s height is usually\nslightly less than their length.";
-        }
-        if (x === 2 && measurementMethod === 'height' && reference == 'uk-who') {
-            // step down at 2 y where children measured standing (height), not lying (length)
-            return "Measure length until age 2y;\nMeasure height after age 2y.\nA child’s height is usually\nslightly less than their length.";
+            returnStringList.push('Measure length until age 2y');
+            returnStringList.push('Measure height after age 2y');
+            returnStringList.push('A child’s height is usually');
+            returnStringList.push('slightly less than their length.');
+            return returnStringList;
+            // return "Measure length until age 2y;\nMeasure height after age 2y.\nA child’s height is usually\nslightly less than their length.";
         }
         if (l === 'For all Children plotted in this shaded area see instructions.' && reference == 'uk-who') {
+            let returnStringList = [];
             // delayed puberty if plotted in this area
             if (sex==='male'){
-                return 'If a plot falls here, pubertal assessment will be required\nand mid-parental centile should be assessed.\nIf they are in puberty or completing puberty,\nthey are below the 0.4th centile and should be referred.\nIn most instances a prepubertal boy plotted in this area\nis growing normally, but comparison with the mid-parental\ncentile and growth trajectory will assist the assessment\nof whether further investigation is needed.';
+                returnStringList.push('If a plot falls here, pubertal assessment will be required and mid-parental centile should be assessed. If they are in puberty or completing puberty, they are below the 0.4th centile and should be referred. In most instances a prepubertIn most instances a prepubertal boy plotted in this area is growing normally, but comparison with the mid-parental centile and growth trajectory will assist the assessment of whether further investigation is needed.');
+                return returnStringList;
             } else {
-                return 'If a plot falls here, pubertal assessment will be required\nand mid-parental centile should be assessed.\nIf they are in puberty or completing puberty,\nthey are below the 0.4th centile and should be referred.\nIn most instances a prepubertal girl plotted in this area\nis growing normally, but comparison with the mid-parental\ncentile and growth trajectory will assist the assessment\nof whether further investigation is needed.';
+                returnStringList.push('If a plot falls here, pubertal assessment will be required');
+                returnStringList.push('and mid-parental centile should be assessed.');
+                returnStringList.push('If they are in puberty or completing puberty,');
+                returnStringList.push('they are below the 0.4th centile and should be referred.');
+                returnStringList.push('In most instances a prepubertal girl plotted in this area');
+                returnStringList.push('is growing normally, but comparison with the mid-parental');
+                returnStringList.push('centile and growth trajectory will assist the assessment');
+                returnStringList.push('of whether further investigation is needed.');
+                return returnStringList;
             }
         }
 
         // Term shaded area text
         if (x < 0.038329911019849415 && x > -0.057494866529774126 && reference ==='uk-who' && measurementMethod === 'weight'){
-            return `${addOrdinalSuffix(l)} centile: \n Babies born in this shaded area\nare term. It is normal for\nbabies to lose weight over\nthe first two weeks of life.\nMedical review should be sought\nif weight has dropped by more\nthan 10% of birth weight or\nweight is still below birth weight\nthree weeks after birth.`;
+            let returnStringList = [];
+            returnStringList.push(`${addOrdinalSuffix(l)} centile:`);
+            returnStringList.push('Babies born in this shaded area');
+            returnStringList.push('are term. It is normal for');
+            returnStringList.push('babies to lose weight over');
+            returnStringList.push('the first two weeks of life.');
+            returnStringList.push('Medical review should be sought');
+            returnStringList.push('if weight has dropped by more');
+            returnStringList.push('than 10% of birth weight or');
+            returnStringList.push('weight is still below birth weight');
+            returnStringList.push('three weeks after birth.');
+            return returnStringList;
         }
         
         // BMI SDS labels
         if (childName.includes("sdsLine")){
-            return `${l} SDS`  
+            let returnStringList = [];
+            returnStringList.push(`${l} SDS`);
+            return returnStringList;
         }
 
         if (childName.includes("centileLine")){
@@ -128,8 +173,10 @@ export function tooltipText(
             
             if (datum.x < 20 && y != null){
                 // fix for duplicate text if tooltip called from mouse point where x > chart area or 
-                // y is ull - situations when hovering below the chart in areas where centile data do not exist
-                return `${addOrdinalSuffix(l)} centile`;
+                // y is null - situations when hovering below the chart in areas where centile data do not exist
+                let returnStringList = [];
+                returnStringList.push(`${addOrdinalSuffix(l)} centile`);
+                return returnStringList;
             }
         }
     }
@@ -137,37 +184,37 @@ export function tooltipText(
 
         // bone age text
         if ((childName==="chronologicalboneage" || childName === "correctedboneage") && b){
-            let concatenatedText = "Bone Age: "
+            let returnStringList = [];
+            returnStringList.push( "Bone Age: ${b.toString()} yrs")
             
-            concatenatedText+=b.toString()+" yrs";
             if (bone_age_sds && !isNaN(bone_age_sds)) {
-                concatenatedText+="\nSDS: "+bone_age_sds.toString();
+                returnStringList.push("SDS: ${bone_age_sds.toString()}");
             }
             if (bone_age_centile && !isNaN(bone_age_centile)) {
-                concatenatedText+="\nCentile: "+bone_age_centile.toString();
+                returnStringList.push("Centile: ${bone_age_centile.toString()}");
             }
             if (bone_age_type && bone_age_type.length > 0) {
                 if (bone_age_type==="greulich-pyle"){
-                    concatenatedText+="\nGreulich & Pyle"
+                    returnStringList.push("Greulich & Pyle");
                 }
                 if (bone_age_type==='tanner-whitehouse-ii'){
-                    concatenatedText+="\nTanner-Whitehouse II";
+                    returnStringList.push("Tanner-Whitehouse II");
                 }
                 if (bone_age_type==='tanner-whitehouse-iii'){
-                    concatenatedText+="\nTanner-Whitehouse III";
+                    returnStringList.push("Tanner-Whitehouse III");
                 }
                 if (bone_age_type==='fels'){
-                    concatenatedText+="\nFels";
+                    returnStringList.push("Fels");
                 }
                 if (bone_age_type==='bonexpert'){
-                    concatenatedText+="\nBoneXpert";
+                    returnStringList.push("BoneXpert");
                 }
                 if (bone_age_label && bone_age_label.length > 0) {
-                    concatenatedText+="\n"+bone_age_label
+                    returnStringList.push(bone_age_label);
                 }
             }
             
-            return concatenatedText;
+            return returnStringList;
         }
 
         /* 
@@ -182,8 +229,8 @@ export function tooltipText(
         const splitCentile = centile_band.split(' ');
         if (splitCentile.length >= 11) {
             const wantedIndex = splitCentile.findIndex((element: string) => element === 'is');
-            splitCentile[wantedIndex] = 'is\n';
-            finalCentile = splitCentile.join(' ').replace('is\n ', 'is\n');
+            splitCentile[wantedIndex] = 'is';
+            finalCentile = splitCentile.join(' ').replace('is ', 'is');
         }
         
         const year=observation_date.split('/')[2]
@@ -191,32 +238,40 @@ export function tooltipText(
         const day=observation_date.split('/')[0]
         const formatted_observation_date = new Date(year,month,day).toLocaleDateString("en-GB", {year: "numeric", month: "short", day: "numeric"});
         
+        let returnStringList = [];
+        
         // measurement data points
         if (x <= 0.0383) {
             // <= 42 weeks
-            
 
             /// plots
             if (observation_value_error === null ) {
                 // && age_error === null temporarily removed from if statement as error in api return object for EDD < observation_date
-
-
                 let corrected_gestational_age=''
                 if (gestational_age){
                     corrected_gestational_age=`${gestational_age.corrected_gestation_weeks}+${gestational_age.corrected_gestation_days} weeks`
+                    returnStringList.push(`${calendar_age}`)
+                    returnStringList.push(`Corrected age: ${corrected_gestational_age} on ${formatted_observation_date} )`)
                 }
                 // sds in square brackets
                 const sds_string = `[SDS: ${sds > 0 ? '+' + Math.round(sds*1000)/1000 : Math.round(sds*1000)/1000 }]`;
                 if (age_type === 'corrected_age') {
-                    const finalCorrectedString = comment.replaceAll(', ', ',\n').replaceAll('. ', '.\n');
-                    return `${calendar_age}\nCorrected age: ${corrected_gestational_age} on ${formatted_observation_date}\n${finalCorrectedString}\n${y} ${measurementSuffix(measurementMethod)} ${ clinicianFocus ? sds_string : '\n' + finalCentile}`;
+                    returnStringList.push(`Corrected age: ${calendar_age} on ${formatted_observation_date} on ${formatted_observation_date}`)
+                    returnStringList.push(`${comment} ${y}`)
+                    returnStringList.push(`${measurementSuffix(measurementMethod)}`);
+                    returnStringList.push(`${ clinicianFocus ? sds_string : finalCentile}`);
+                    return returnStringList;
                 }
                 if (age_type === 'chronological_age') {
-                    let finalChronologicalString = comment.replaceAll(', ', ',\n').replaceAll('. ', '.\n');
-                    return `Chronological age: ${calendar_age}\n${formatted_observation_date}\n${finalChronologicalString}\n${y} ${measurementSuffix(measurementMethod)} ${ clinicianFocus ? sds_string : '\n' + finalCentile}`;
+                    returnStringList.push(`Chronological age: ${calendar_age} on ${formatted_observation_date}`)
+                    returnStringList.push(`${comment} ${y}`)
+                    returnStringList.push(`${measurementSuffix(measurementMethod)}`);
+                    returnStringList.push(`${ clinicianFocus ? sds_string : finalCentile}`);
+                    return returnStringList;
                 }
             }
         } else {
+                
             // over 42 weeks
             // if no errors, return the ages, measurement and calculations
             let correctedPercentageMedianBMI = ""
@@ -224,31 +279,34 @@ export function tooltipText(
             if (measurementMethod==="bmi"){
                 correctedPercentageMedianBMI = `Percentage median BMI: ${Math.round(corrected_percentage_median_bmi)}%`
                 chronologicalPercentageMedianBMI = `Percentage median BMI: ${Math.round(chronological_percentage_median_bmi)}%`
+                returnStringList.push(correctedPercentageMedianBMI)
+                returnStringList.push(chronologicalPercentageMedianBMI)
             }
             
             // sds in square brackets
             const sds_string = `[SDS: ${sds > 0 ? '+' + Math.round(sds*1000)/1000 : Math.round(sds*1000)/1000 }]`;
             
             if (age_type === 'corrected_age' && x > 0.0383) {
-                const finalCorrectedString = comment.replaceAll(', ', ',\n').replaceAll('. ', '.\n');
-                let returnString =  `Corrected age: ${calendar_age} on ${formatted_observation_date}\n${finalCorrectedString}\n${y} ${measurementSuffix(measurementMethod)} ${ clinicianFocus ? sds_string : '\n' + finalCentile}`;
+                returnStringList.push(`Corrected age: ${calendar_age} on ${formatted_observation_date}`);
+                returnStringList.push(`${comment}`)
+                returnStringList.push(`${y} ${measurementSuffix(measurementMethod)}`);
+                returnStringList.push(`${ clinicianFocus ? sds_string : finalCentile}`);
                 if (measurementMethod==="bmi"){
-                    returnString += `\n${correctedPercentageMedianBMI}`
+                    returnStringList.push(`${correctedPercentageMedianBMI}`);
                 }
-                return returnString;
+                return returnStringList;
 
             }
             if (age_type === 'chronological_age') {
-                
-                let finalChronologicalString = comment
-                    .replaceAll(', ', ',\n')
-                    .replaceAll('. ', '.\n')
-                    .replaceAll('account ', 'account\n');
-                let returnString =  `Chronological age: ${calendar_age} on ${formatted_observation_date}\n${finalChronologicalString}\n${y} ${measurementSuffix(measurementMethod)} ${ clinicianFocus ? sds_string : '\n' + finalCentile}`;
+                let returnString =  `Chronological age: ${calendar_age} on ${formatted_observation_date}`;
+                returnStringList.push(returnString);
+                returnStringList.push(`${comment}`)
+                returnStringList.push(`${y} ${measurementSuffix(measurementMethod)}`);
+                returnStringList.push(`${ clinicianFocus ? sds_string : finalCentile}`);
                 if (measurementMethod === "bmi"){
-                    returnString += `\n${chronologicalPercentageMedianBMI}`;
+                    returnStringList.push(`${chronologicalPercentageMedianBMI}`);
                 }
-                return returnString;
+                return returnStringList;
             }
         }
     }

--- a/src/functions/tooltips.ts
+++ b/src/functions/tooltips.ts
@@ -130,7 +130,14 @@ export function tooltipText(
             let returnStringList = [];
             // delayed puberty if plotted in this area
             if (sex==='male'){
-                returnStringList.push('If a plot falls here, pubertal assessment will be required and mid-parental centile should be assessed. If they are in puberty or completing puberty, they are below the 0.4th centile and should be referred. In most instances a prepubertIn most instances a prepubertal boy plotted in this area is growing normally, but comparison with the mid-parental centile and growth trajectory will assist the assessment of whether further investigation is needed.');
+                returnStringList.push('If a plot falls here, pubertal assessment will be required');
+                returnStringList.push('and mid-parental centile should be assessed.');
+                returnStringList.push('If they are in puberty or completing puberty,');
+                returnStringList.push('they are below the 0.4th centile and should be referred.');
+                returnStringList.push('In most instances a prepubertal boy plotted in this area');
+                returnStringList.push('is growing normally, but comparison with the mid-parental');
+                returnStringList.push('centile and growth trajectory will assist the assessment');
+                returnStringList.push('of whether further investigation is needed.');
                 return returnStringList;
             } else {
                 returnStringList.push('If a plot falls here, pubertal assessment will be required');


### PR DESCRIPTION
### Overview
This PR fixes a couple of items
1. The failure for tooltips of more than one line to render in Safari.
2. the scoping of the x axis to the data takes into account of the bone age if provided

### Code changes
- `CentileChart.tsx` and `tooltips.ts`: tooltips have been refactored to return an array of strings which in turn have `\n` added. The number of strings in the array is used to override the `flyoutHeight` prop in the `VictoryTooltip` to set the tooltip height dynamically. This works now both in chrome and safari.
- `getDomainsAndData` sets lowest x and highest x in the domains to the bone age if it is the highest or lowest value. This fixes #102

### Documentation changes (done or required as a result of this PR)
Please describe any changes to documentation here.

### Related Issues
List any issues related to this PR here.

### Mentions
@mentions of the person or team responsible for reviewing proposed changes.
