### PR TITLE
Label-angles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rcpch/digital-growth-charts-react-component-library",
-    "version": "7.3.1",
+    "version": "7.3.2",
     "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
     "main": "build/index.js",
     "module": "build/esm.index.js",

--- a/src/CentileChart/CentileChart.tsx
+++ b/src/CentileChart/CentileChart.tsx
@@ -550,7 +550,7 @@ function CentileChart({
                                                             angle={({ index }) => {
                                                                 return labelAngle(
                                                                     centile.data,
-                                                                    index,
+                                                                    parseInt(index.toString()),
                                                                     chartScaleType,
                                                                     measurementMethod,
                                                                     domains,
@@ -558,10 +558,11 @@ function CentileChart({
                                                             }}
                                                             style={styles.centileLabel}
                                                             backgroundStyle={{ fill: 'white' }}
-                                                            backgroundPadding={{ top: 1, bottom: 1, left: 3, right: 3 }}
+                                                            backgroundPadding={{ top: 1, bottom: 1, left: 1, right: 1 }}
                                                             textAnchor={'middle'}
                                                             verticalAnchor={'middle'}
                                                             dy={0}
+                                                            dx={0}
                                                         />
                                                     }
                                                 />
@@ -596,7 +597,7 @@ function CentileChart({
                                                             angle={({ index }) => {
                                                                 return labelAngle(
                                                                     centile.data,
-                                                                    index,
+                                                                    parseInt(index.toString()),
                                                                     chartScaleType,
                                                                     measurementMethod,
                                                                     domains,
@@ -610,9 +611,10 @@ function CentileChart({
                                                                 },
                                                             ]}
                                                             backgroundStyle={{ fill: 'white' }}
-                                                            backgroundPadding={{ top: 0, bottom: 0, left: 3, right: 3 }}
+                                                            backgroundPadding={{ top: 0, bottom: 0, left: 0, right: 0 }}
                                                             textAnchor={'middle'}
                                                             verticalAnchor={'middle'}
+                                                            dx={0}
                                                             dy={0}
                                                         />
                                                     }
@@ -655,7 +657,7 @@ function CentileChart({
                                                         centileLabels &&
                                                         labelIndexInterval(props.index, props.data, domains) &&
                                                         props.index > 0
-                                                            ? [sdsLine.sds]
+                                                            ? [addOrdinalSuffix(sdsLine.sds)]
                                                             : null
                                                     }
                                                     labelComponent={
@@ -663,7 +665,7 @@ function CentileChart({
                                                             angle={({ index }) => {
                                                                 return labelAngle(
                                                                     sdsLine.data,
-                                                                    index,
+                                                                    parseInt(index.toString()),
                                                                     chartScaleType,
                                                                     measurementMethod,
                                                                     domains,
@@ -671,8 +673,10 @@ function CentileChart({
                                                             }}
                                                             style={{ fill: styles.sdsLine.data.stroke, fontSize: 10.0 }}
                                                             backgroundStyle={{ fill: 'white' }}
-                                                            textAnchor={'end'}
-                                                            dy={5}
+                                                            textAnchor={'middle'}
+                                                            verticalAnchor={'middle'}
+                                                            dy={0}
+                                                            dx={0}
                                                         />
                                                     }
                                                 />

--- a/src/functions/labelIndexInterval.ts
+++ b/src/functions/labelIndexInterval.ts
@@ -6,12 +6,15 @@ export function labelIndexInterval(index: number, data: any[], domains: { x: num
     if (data == undefined) {
         return false;
     }
+    if (index <= 0 || index >= data.length - 2) {
+        return undefined; // Cannot calculate angle at the edges.
+    }
     const bill = data.filter((d: any) => {
         if (d.x > domains.x[0] && d.x < domains.x[1]) {
             return d;
         }
     });
-    let numberOfItemsBetweenLabels = Math.floor(bill.length / 3); // 3 labels per line - this will serve as an index to split the data into 4 sections
+    let numberOfItemsBetweenLabels = Math.floor(bill.length / 2); // 2 labels per line - this will serve as an index to split the data into 4 sections
 
     return index % numberOfItemsBetweenLabels == 0;
 }


### PR DESCRIPTION
### Overview
Fix for issue #143 identified by @gabrielfreitas (thank you)

There are in fact two problems
1. the interval between the labels did not resize on zoom
2. the inline labels should rotate to the gradient of the centile line. This is only partially fixed.

Issue one was fixed with a refactor of the`labelIndexInterval` function. This now mandates 2 labels to be visible in the viewport at any time, irrespective of the domains of the chart and degree of zoom.

Issue 2 is only partially fixed and actually I am not completely sure how best completely to solve this. The problem resides within the `labelAngle` function which receives the data for each line, the domains of the chart, the reference, sex and other parameters and uses this to identify x and y values above and below the label to calculate the gradient and rotate the label accordingly. Where the x axis values are close together (such as in infancy), a multiplier is used to increase the accuracy. 

The difficulty here possibly sits within the way Victory handles labels as there seems to be some offsetting that occurs that interferes as the labels are perfect in some places and off by some margin in others. This has meant a certain amount of trial and error with conditionals for different charts and measurement methods. Not ideal. If someone has a more concise approach with a better knowledge of the VictoryLabel component I am all ears. 

This PR at least fixes the core problem and restores the label angle to how it was.

closes #143