### PR TITLE
Midparental-height-centile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rcpch/digital-growth-charts-react-component-library",
-    "version": "7.3.5",
+    "version": "7.3.6",
     "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
     "main": "build/index.js",
     "module": "build/esm.index.js",

--- a/src/functions/tooltips.ts
+++ b/src/functions/tooltips.ts
@@ -84,6 +84,7 @@ export function tooltipText(
     if (midParentalHeightData) {
         const {
             mid_parental_height,
+            mid_parental_height_centile,
             mid_parental_height_sds,
             mid_parental_height_lower_value,
             mid_parental_height_upper_value,
@@ -102,7 +103,7 @@ export function tooltipText(
             }
             if (childName === 'centileMPH' || childName === 'areaMPH') {
                 returnStringList.push(
-                    `Mid-Parental Height: ${Math.round(mid_parental_height * 10) / 10} cm (${addOrdinalSuffix(Math.round(parseFloat(l)))} centile, SDS: ${Math.round(mid_parental_height_sds * 1000) / 1000})`,
+                    `Mid-Parental Height: ${Math.round(mid_parental_height * 10) / 10} cm (${addOrdinalSuffix(Math.round(mid_parental_height_centile * 100) / 100)} centile, SDS: ${Math.round(mid_parental_height_sds * 1000) / 1000})`,
                 );
                 returnStringList.push(
                     `Range(+/-2 centiles): ${Math.round(mid_parental_height_lower_value * 10) / 10} cm - ${Math.round(mid_parental_height_upper_value * 10) / 10} cm`,


### PR DESCRIPTION
### Overview

Closes #137

In fact the fix for this issue lies in the server, where return values for the centile were complicated if they rounded to 0. This is now fixed in the server v4.3.4

This PR meanwhile fixes the label in the midparental centile so that it returns to 2 decimal places, important if the centile returned is < 1.

Also bumps version to 7.3.6