### PR TITLE
Export-umd-as-min

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -12,5 +12,6 @@
         "@babel/preset-typescript",
         "@babel/preset-react"
     ],
-    "plugins": []
+    "plugins": [],
+    "compact": true
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
                   echo "## SRI Hash" >> $GITHUB_STEP_SUMMARY
                   echo "For secure CDN usage with this release:" >> $GITHUB_STEP_SUMMARY
                   echo "\`\`\`html" >> $GITHUB_STEP_SUMMARY
-                  echo "<script src=\"https://cdn.jsdelivr.net/npm/@rcpch/digital-growth-charts-react-component-library@${{ github.event.release.tag_name }}/build/umd/rcpch-digital-growth-charts.umd.js\"" >> $GITHUB_STEP_SUMMARY
+                  echo "<script src=\"https://cdn.jsdelivr.net/npm/@rcpch/digital-growth-charts-react-component-library@${{ github.event.release.tag_name }}/build/umd/rcpch-digital-growth-charts.umd.min.js\"" >> $GITHUB_STEP_SUMMARY
                   echo "        integrity=\"$SRI_HASH\"" >> $GITHUB_STEP_SUMMARY
                   echo "        crossorigin=\"anonymous\"></script>" >> $GITHUB_STEP_SUMMARY
                   echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/demo.html
+++ b/demo.html
@@ -8,7 +8,7 @@
         <!-- RCPCH Growth Charts library with SRI hash for security -->
         <script
             src="https://cdn.jsdelivr.net/npm/@rcpch/digital-growth-charts-react-component-library@7.3.7/build/umd/rcpch-digital-growth-charts.umd.min.js"
-            integrity="sha384-Te61Ux4WqUzrwMJb8pDAtE92B3sYPlsR31W91KLAA6geskluSC40Z+wT14We0ngF"
+            integrity="sha384-58O0gogqfMtNv3ObTx3Y/xbsYnOODbNU1efCjiGPdl54DISxXc8YQf+UOXJQ3LPh%"
             crossorigin="anonymous"
             defer
         ></script>

--- a/demo.html
+++ b/demo.html
@@ -7,7 +7,7 @@
         <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" defer></script>
         <!-- RCPCH Growth Charts library with SRI hash for security -->
         <script
-            src="https://cdn.jsdelivr.net/npm/@rcpch/digital-growth-charts-react-component-library@7.3.4/build/umd/rcpch-digital-growth-charts.umd.min.js"
+            src="https://cdn.jsdelivr.net/npm/@rcpch/digital-growth-charts-react-component-library@7.3.7/build/umd/rcpch-digital-growth-charts.umd.min.js"
             integrity="sha384-Te61Ux4WqUzrwMJb8pDAtE92B3sYPlsR31W91KLAA6geskluSC40Z+wT14We0ngF"
             crossorigin="anonymous"
             defer

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
     "name": "@rcpch/digital-growth-charts-react-component-library",
-    "version": "7.3.6",
+    "version": "7.3.7",
     "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
     "main": "build/index.js",
     "module": "build/esm.index.js",
     "types": "build/index.d.ts",
-    "unpkg": "build/umd/rcpch-digital-growth-charts.umd.js",
-    "jsdelivr": "build/umd/rcpch-digital-growth-charts.umd.js",
+    "unpkg": "build/umd/rcpch-digital-growth-charts.umd.min.js",
+    "jsdelivr": "build/umd/rcpch-digital-growth-charts.umd.min.js",
     "files": [
         "build"
     ],
@@ -14,7 +14,7 @@
         "test": "jest --env=jsdom",
         "build": "cross-env NODE_OPTIONS=--max-old-space-size=5120 ROLLUP_WATCH=false rollup -c --bundleConfigAsCjs",
         "build:umd": "rollup -c --environment UMD",
-        "generate-sri": "cat build/umd/rcpch-digital-growth-charts.umd.js | openssl dgst -sha384 -binary | openssl base64 -A",
+        "generate-sri": "cat build/umd/rcpch-digital-growth-charts.umd.min.js | openssl dgst -sha384 -binary | openssl base64 -A",
         "storybook": "storybook dev -p 6006",
         "build-storybook": "storybook build",
         "prettier:check": "prettier --check .",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -94,6 +94,9 @@ export default [
             },
         ],
         plugins: [
+            // this replaces all instances of process (eg process.env.NODE_ENV) which prevents the build from failing
+            // this is done by creating a stub file that exports an empty object
+            // and replacing all instances of process with the stub file
             alias({
                 entries: [
                     {
@@ -124,7 +127,19 @@ export default [
                 extensions: ['.ts', '.tsx'],
             }),
             typescript(),
-            terser(),
+            terser({
+                // some of the references are pretty big and chunking them would be difficult. This suppresses the warnings
+                compress: {
+                    pure_getters: true,
+                    dead_code: true,
+                    toplevel: true,
+                },
+                mangle: true,
+                output: {
+                    comments: false,
+                    max_line_len: 1000000,
+                },
+            }),
             json(),
             versionInjector(),
             image(),

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -81,7 +81,7 @@ export default [
         external: ['react', 'react-dom', 'react-dom/client'],
         output: [
             {
-                file: 'build/umd/rcpch-digital-growth-charts.umd.js',
+                file: 'build/umd/rcpch-digital-growth-charts.umd.min.js',
                 format: 'umd',
                 name: 'RCPCHGrowthCharts',
                 exports: 'default',


### PR DESCRIPTION
### Overview
The SRI hash runs on build and is set for a package name of `build/umd/rcpch-digital-growth-charts.umd.js`. Jsdelivr though recognizes the file is minified and changes the name to `build/umd/rcpch-digital-growth-charts.umd.min.js` which in turn changes the hash.

This fixes the exported file name in roll up to reflect that it is minified and updates where it is mentioned. 
Incidentally it alters the babelrc options to suppress the warning about chunk sizes when bundling some of the larger reference data files which can't really be broken up without a headache

bumps version to 7.3.7