### PR TITLE
Fix crashing SDS charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@rcpch/digital-growth-charts-react-component-library",
-    "version": "7.3.5",
+    "version": "7.3.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@rcpch/digital-growth-charts-react-component-library",
-            "version": "7.3.5",
+            "version": "7.3.8",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "sass": "1.70.0",

--- a/src/SDSChart/SDSChart.tsx
+++ b/src/SDSChart/SDSChart.tsx
@@ -180,10 +180,10 @@ const SDSChart: React.FC<SDSChartProps> = ({
     }
 
     if (
-        (childMeasurements.height[0]?.birth_data.gestation_weeks >= 37 ||
-            childMeasurements.weight[0]?.birth_data.gestation_weeks >= 37 ||
-            childMeasurements.bmi[0]?.birth_data.gestation_weeks >= 37 ||
-            childMeasurements.ofc[0]?.birth_data.gestation_weeks >= 37) &&
+        (childMeasurements.height?.[0]?.birth_data.gestation_weeks >= 37 ||
+            childMeasurements.weight?.[0]?.birth_data.gestation_weeks >= 37 ||
+            childMeasurements.bmi?.[0]?.birth_data.gestation_weeks >= 37 ||
+            childMeasurements.ofc?.[0]?.birth_data.gestation_weeks >= 37) &&
         measurementMethod === 'weight' &&
         reference === 'uk-who' &&
         domains?.x[0] < 0.038329911019849415 && // 2 weeks postnatal
@@ -394,8 +394,8 @@ const SDSChart: React.FC<SDSChartProps> = ({
                             linkLineStyles = styles?.ofcSDS;
                             showData = showOFC;
                         }
-
-                        if (measurementTypeItem.measurementTypeData.length == 0 || !showData) {
+                        
+                        if (!measurementTypeItem.measurementTypeData || measurementTypeItem.measurementTypeData.length == 0 || !showData) {
                             // if there is no data for this measurement, do not run this code as leads to css errors
                             return;
                         }

--- a/src/functions/buildListOfMeasurementMethods.ts
+++ b/src/functions/buildListOfMeasurementMethods.ts
@@ -8,7 +8,8 @@ export const selectedMeasurementMethods = (
     styles: { [key: string]: any },
 ) => {
     const finalList: VictoryLegendDatum[] = [];
-    if (childMeasurements.height.length > 0) {
+
+    if (childMeasurements.height?.length > 0) {
         const symbol = symbolForMeasurementType('height');
         const name = nameForMeasurementMethod('height');
 
@@ -23,7 +24,7 @@ export const selectedMeasurementMethods = (
             },
         });
     }
-    if (childMeasurements.weight.length > 0) {
+    if (childMeasurements.weight?.length > 0) {
         const symbol = symbolForMeasurementType('weight');
         const name = nameForMeasurementMethod('weight');
         finalList.push({
@@ -37,7 +38,7 @@ export const selectedMeasurementMethods = (
             },
         });
     }
-    if (childMeasurements.bmi.length > 0) {
+    if (childMeasurements.bmi?.length > 0) {
         const symbol = symbolForMeasurementType('bmi');
         const name = nameForMeasurementMethod('bmi');
         finalList.push({
@@ -51,7 +52,7 @@ export const selectedMeasurementMethods = (
             },
         });
     }
-    if (childMeasurements.ofc.length > 0) {
+    if (childMeasurements.ofc?.length > 0) {
         const symbol = symbolForMeasurementType('ofc');
         const name = nameForMeasurementMethod('ofc');
         finalList.push({


### PR DESCRIPTION
Fixes #158 

- Support `measurements` only containing some measurement keys (eg just `bmi`, not `bmi` and `weight` etc)
- Add some defensive code in SDS chart against empty measurements