### PR TITLE
v7.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rcpch/digital-growth-charts-react-component-library",
-  "version": "7.3.9",
+  "version": "7.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rcpch/digital-growth-charts-react-component-library",
-      "version": "7.3.9",
+      "version": "7.4.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "styled-components": "6.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rcpch/digital-growth-charts-react-component-library",
-  "version": "7.3.9",
+  "version": "7.4.0",
   "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
   "main": "build/index.js",
   "module": "build/esm.index.js",


### PR DESCRIPTION
- https://github.com/rcpch/digital-growth-charts-react-component-library/pull/162
- https://github.com/rcpch/digital-growth-charts-react-component-library/pull/163
- https://github.com/rcpch/digital-growth-charts-react-component-library/pull/164

Bump minor version as we now allow React 19 but still support React 18.

The UMD package has changed path (`umd` subfolder removed)

- *Before*: https://cdn.jsdelivr.net/npm/@rcpch/digital-growth-charts-react-component-library@7.3.9/build/umd/rcpch-digital-growth-charts.umd.min.js
- *After*: https://cdn.jsdelivr.net/npm/@rcpch/digital-growth-charts-react-component-library@7.4.0/build/rcpch-digital-growth-charts.umd.min.js

(https://github.com/rcpch/digital-growth-charts-react-component-library/pull/164/commits/7d9f4aed29a0723d79472efe6503280f6f75cfef)

I'm going to stretch semver here and avoid burning a major version on that as AFAIK nobody is using it in production and it doesn't change the consuming code, just the script tag import.