### PR TITLE
Fix lodash dependabot warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10862,9 +10862,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.camelcase": {


### PR DESCRIPTION
Only used as a transitive dev dependency so doesn't need a release.

- https://github.com/rcpch/digital-growth-charts-react-component-library/security/dependabot/96
- https://github.com/rcpch/digital-growth-charts-react-component-library/security/dependabot/97