### PR TITLE
Dependabot warning fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@rcpch/digital-growth-charts-react-component-library",
-    "version": "7.5.0",
+    "version": "7.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@rcpch/digital-growth-charts-react-component-library",
-            "version": "7.5.0",
+            "version": "7.5.1",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "styled-components": "^6.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1251,9 +1251,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-            "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+            "version": "7.29.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+            "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8442,9 +8442,9 @@
             "peer": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -11751,9 +11751,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "funding": [
                 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "7.5.0",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
-                "styled-components": "6.1.19",
+                "styled-components": "^6.4.1",
                 "victory": "37.3.6"
             },
             "devDependencies": {
@@ -2154,24 +2154,18 @@
             }
         },
         "node_modules/@emotion/is-prop-valid": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-            "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+            "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
             "license": "MIT",
             "dependencies": {
-                "@emotion/memoize": "^0.8.1"
+                "@emotion/memoize": "^0.9.0"
             }
         },
         "node_modules/@emotion/memoize": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-            "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
-            "license": "MIT"
-        },
-        "node_modules/@emotion/unitless": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-            "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
             "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -5322,12 +5316,6 @@
                 "csstype": "^3.2.2"
             }
         },
-        "node_modules/@types/stylis": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
-            "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
-            "license": "MIT"
-        },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -7422,7 +7410,6 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/d3-array": {
@@ -11153,6 +11140,7 @@
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
             "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -11633,6 +11621,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -13389,12 +13378,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/shallowequal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-            "license": "MIT"
-        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -13465,6 +13448,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -13808,20 +13792,15 @@
             }
         },
         "node_modules/styled-components": {
-            "version": "6.1.19",
-            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
-            "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
+            "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
             "license": "MIT",
             "dependencies": {
-                "@emotion/is-prop-valid": "1.2.2",
-                "@emotion/unitless": "0.8.1",
-                "@types/stylis": "4.2.5",
+                "@emotion/is-prop-valid": "1.4.0",
                 "css-to-react-native": "3.2.0",
-                "csstype": "3.1.3",
-                "postcss": "8.4.49",
-                "shallowequal": "1.1.0",
-                "stylis": "4.3.2",
-                "tslib": "2.6.2"
+                "csstype": "3.2.3",
+                "stylis": "4.3.6"
             },
             "engines": {
                 "node": ">= 16"
@@ -13831,49 +13810,22 @@
                 "url": "https://opencollective.com/styled-components"
             },
             "peerDependencies": {
+                "css-to-react-native": ">= 3.2.0",
                 "react": ">= 16.8.0",
-                "react-dom": ">= 16.8.0"
-            }
-        },
-        "node_modules/styled-components/node_modules/csstype": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "license": "MIT"
-        },
-        "node_modules/styled-components/node_modules/postcss": {
-            "version": "8.4.49",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-            "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
+                "react-dom": ">= 16.8.0",
+                "react-native": ">= 0.68.0"
             },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
+            "peerDependenciesMeta": {
+                "css-to-react-native": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                }
             }
-        },
-        "node_modules/styled-components/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "license": "0BSD"
         },
         "node_modules/stylehacks": {
             "version": "5.1.1",
@@ -13907,9 +13859,9 @@
             }
         },
         "node_modules/stylis": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
-            "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+            "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
             "license": "MIT"
         },
         "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rcpch/digital-growth-charts-react-component-library",
-    "version": "7.5.0",
+    "version": "7.5.1",
     "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
     "main": "build/index.js",
     "module": "build/esm.index.js",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "react-dom": "^19.1.0 || ^18.3.1"
     },
     "dependencies": {
-        "styled-components": "6.1.19",
+        "styled-components": "^6.4.1",
         "victory": "37.3.6"
     },
     "devDependencies": {


### PR DESCRIPTION
https://github.com/rcpch/digital-growth-charts-react-component-library/security/dependabot/100

https://github.com/rcpch/digital-growth-charts-react-component-library/security/dependabot/99

https://github.com/rcpch/digital-growth-charts-react-component-library/security/dependabot/98

also bump styled-components to fix a medium severity warning in postcss. As such a patch version release.