### PR TITLE
Fix node version and roll back version to 7.5.1 to try and release again

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
             - uses: actions/checkout@v6
             - uses: actions/setup-node@v6
               with:
-                  node-version: "22.2.1"
+                  node-version: "22.22.1"
                   registry-url: "https://registry.npmjs.org"
 
             - name: Ensure npm CLI >= 11.5.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@rcpch/digital-growth-charts-react-component-library",
-    "version": "7.5.2",
+    "version": "7.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@rcpch/digital-growth-charts-react-component-library",
-            "version": "7.5.2",
+            "version": "7.5.1",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "styled-components": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rcpch/digital-growth-charts-react-component-library",
-    "version": "7.5.2",
+    "version": "7.5.1",
     "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
     "main": "build/index.js",
     "module": "build/esm.index.js",


### PR DESCRIPTION
Typo in Node version. I don't think we need the extra 7.5.2 release as we should be able to delete the releases and tags and just create them again