### PR TITLE
fix/midparental-height-fails-to-render

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,7 @@
         "source.fixAll": "explicit"
     },
     "git.enableCommitSigning": true,
-    {
-        "editor.formatOnSave": true,
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-      }
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "jest.enable": true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rcpch/digital-growth-charts-react-component-library",
-    "version": "7.5.1",
+    "version": "7.5.2",
     "description": "A React component library for the RCPCH digital growth charts using Rollup, TypeScript and Styled-Components",
     "main": "build/index.js",
     "module": "build/esm.index.js",

--- a/src/functions/getFilteredMidParentalHeightData.test.ts
+++ b/src/functions/getFilteredMidParentalHeightData.test.ts
@@ -1,0 +1,128 @@
+import { getFilteredMidParentalHeightData } from './getFilteredMidParentalHeightData';
+import { MidParentalHeightObject } from '../interfaces/MidParentalHeightObject';
+import { Measurement } from '../interfaces/RCPCHMeasurementObject';
+
+const makeMeasurement = (correctedAge: number): Measurement =>
+    ({
+        plottable_data: {
+            centile_data: {
+                corrected_decimal_age_data: {
+                    x: correctedAge,
+                },
+            },
+        },
+    }) as Measurement;
+
+const makeMidParentalHeightData = (): MidParentalHeightObject => ({
+    mid_parental_height_centile: 50,
+    mid_parental_height_centile_data: [
+        {
+            uk_who_child: {
+                male: {
+                    height: [
+                        {
+                            centile: 50,
+                            data: [
+                                { x: 5, y: 110 },
+                                { x: 20, y: 180 },
+                            ],
+                        },
+                    ],
+                },
+                female: {
+                    height: [
+                        {
+                            centile: 50,
+                            data: [
+                                { x: 5, y: 108 },
+                                { x: 20, y: 170 },
+                            ],
+                        },
+                    ],
+                },
+            },
+        },
+    ],
+    mid_parental_height_lower_centile_data: [
+        {
+            uk_who_child: {
+                male: {
+                    height: [
+                        {
+                            centile: 9,
+                            data: [
+                                { x: 5, y: 102 },
+                                { x: 20, y: 172 },
+                            ],
+                        },
+                    ],
+                },
+                female: {
+                    height: [
+                        {
+                            centile: 9,
+                            data: [
+                                { x: 5, y: 100 },
+                                { x: 20, y: 162 },
+                            ],
+                        },
+                    ],
+                },
+            },
+        },
+    ],
+    mid_parental_height_upper_centile_data: [
+        {
+            uk_who_child: {
+                male: {
+                    height: [
+                        {
+                            centile: 91,
+                            data: [
+                                { x: 5, y: 118 },
+                                { x: 20, y: 188 },
+                            ],
+                        },
+                    ],
+                },
+                female: {
+                    height: [
+                        {
+                            centile: 91,
+                            data: [
+                                { x: 5, y: 116 },
+                                { x: 20, y: 178 },
+                            ],
+                        },
+                    ],
+                },
+            },
+        },
+    ],
+});
+
+describe('getFilteredMidParentalHeightData regression tests', () => {
+    it('does not mutate source MPH data when called before measurements arrive', () => {
+        const mph = makeMidParentalHeightData();
+
+        const firstCall = getFilteredMidParentalHeightData('uk-who', [], mph, 'male');
+        expect(firstCall?.[0].midParentalCentile[0].data).toEqual([{ x: 20, y: 180 }]);
+
+        // Input object remains intact for subsequent calls.
+        expect(
+            mph.mid_parental_height_centile_data?.[0].uk_who_child?.male?.height?.[0].data,
+        ).toHaveLength(2);
+
+        const secondCall = getFilteredMidParentalHeightData('uk-who', [makeMeasurement(5)], mph, 'male');
+        expect(secondCall?.[0].midParentalCentile[0].data).toEqual([{ x: 5, y: 110 }]);
+    });
+
+    it('uses max corrected age rather than last array item', () => {
+        const mph = makeMidParentalHeightData();
+        const unsortedMeasurements = [makeMeasurement(5), makeMeasurement(2)];
+
+        const result = getFilteredMidParentalHeightData('uk-who', unsortedMeasurements, mph, 'male');
+
+        expect(result?.[0].midParentalCentile[0].data).toEqual([{ x: 5, y: 110 }]);
+    });
+});

--- a/src/functions/getFilteredMidParentalHeightData.ts
+++ b/src/functions/getFilteredMidParentalHeightData.ts
@@ -11,6 +11,24 @@ function isCDCReferences(data: UKWHOReferences | CDCReferences): data is CDCRefe
     return 'fenton' in data || 'cdc_infant' in data || 'cdc_child' in data;
 }
 
+function filterCentilesByRange(centiles: ICentile[], lowerLimit: number, upperLimit: number): ICentile[] {
+    return centiles.map((centile: ICentile) => {
+        if (!centile.data) {
+            return { ...centile };
+        }
+
+        const filteredData = centile.data.filter((measurementItem) => {
+            const x = measurementItem['x'];
+            return typeof x === 'number' && x >= lowerLimit && x <= upperLimit;
+        });
+
+        return {
+            ...centile,
+            data: filteredData,
+        };
+    });
+}
+
 export const getFilteredMidParentalHeightData = (
     reference: 'uk-who' | 'cdc' | 'turner' | 'trisomy-21' | 'trisomy-21-aap' | 'who',
     childMeasurements: Measurement[],
@@ -22,128 +40,103 @@ export const getFilteredMidParentalHeightData = (
         return;
     }
 
+    const centileReferenceData = midParentalHeightData.mid_parental_height_centile_data;
+    const lowerCentileReferenceData = midParentalHeightData.mid_parental_height_lower_centile_data;
+    const upperCentileReferenceData = midParentalHeightData.mid_parental_height_upper_centile_data;
+
     if (
         midParentalHeightData.mid_parental_height_centile &&
-        midParentalHeightData.mid_parental_height_centile_data.length > 0
+        centileReferenceData &&
+        lowerCentileReferenceData &&
+        upperCentileReferenceData &&
+        centileReferenceData.length > 0
     ) {
         let upperLimit = 20;
         let lowerLimit = 19.75;
 
         if (childMeasurements.length > 0) {
-            const latestAge =
-                childMeasurements[childMeasurements.length - 1].plottable_data.centile_data.corrected_decimal_age_data
-                    .x;
+            const ages = childMeasurements
+                .map((measurement) => measurement.plottable_data.centile_data.corrected_decimal_age_data.x)
+                .filter((age): age is number => typeof age === 'number' && Number.isFinite(age));
 
-            if (latestAge < 3 / 12) {
-                upperLimit = latestAge + 2 / 52;
-                lowerLimit = latestAge - 2 / 52;
-            } else if (latestAge >= 3 / 12 && latestAge < 3) {
-                upperLimit = latestAge + 4 / 52;
-                lowerLimit = latestAge - 4 / 52;
-            } else if (latestAge >= 3 && latestAge < 12) {
-                upperLimit = latestAge + 2 / 12;
-                lowerLimit = latestAge - 2 / 12;
-            } else {
-                upperLimit = latestAge + 6 / 12;
-                lowerLimit = latestAge - 6 / 12;
+            const latestAge = ages.length > 0 ? Math.max(...ages) : null;
+
+            if (latestAge !== null) {
+                if (latestAge < 3 / 12) {
+                    upperLimit = latestAge + 2 / 52;
+                    lowerLimit = latestAge - 2 / 52;
+                } else if (latestAge >= 3 / 12 && latestAge < 3) {
+                    upperLimit = latestAge + 1 / 12;
+                    lowerLimit = latestAge - 1 / 12;
+                } else if (latestAge >= 3 && latestAge < 12) {
+                    upperLimit = latestAge + 2 / 12;
+                    lowerLimit = latestAge - 2 / 12;
+                } else {
+                    upperLimit = latestAge + 6 / 12;
+                    lowerLimit = latestAge - 6 / 12;
+                }
             }
         }
 
-        let newReferenceObject: ClientMidparentalCentilesObject[] = [];
+        const newReferenceObject: ClientMidparentalCentilesObject[] = [];
 
-        midParentalHeightData.mid_parental_height_centile_data.map(
-            (referenceData: UKWHOReferences | CDCReferences, index) => {
-                // get the midparental centile data
+        centileReferenceData.forEach((referenceData: UKWHOReferences | CDCReferences, index) => {
+            // get the midparental centile data
 
-                let centiles;
-                let lowercentiles;
-                let uppercentiles;
-                if (reference === 'uk-who' && isUKWHOReferences(referenceData)) {
-                    centiles =
-                        referenceData.uk90_preterm ||
-                        referenceData.uk_who_infant ||
-                        referenceData.uk_who_child ||
-                        referenceData.uk90_child;
-                    lowercentiles =
-                        midParentalHeightData.mid_parental_height_lower_centile_data[index].uk90_preterm ||
-                        midParentalHeightData.mid_parental_height_lower_centile_data[index].uk_who_infant ||
-                        midParentalHeightData.mid_parental_height_lower_centile_data[index].uk_who_child ||
-                        midParentalHeightData.mid_parental_height_lower_centile_data[index].uk90_child;
-                    uppercentiles =
-                        midParentalHeightData.mid_parental_height_upper_centile_data[index].uk90_preterm ||
-                        midParentalHeightData.mid_parental_height_upper_centile_data[index].uk_who_infant ||
-                        midParentalHeightData.mid_parental_height_upper_centile_data[index].uk_who_child ||
-                        midParentalHeightData.mid_parental_height_upper_centile_data[index].uk90_child;
-                } else if (reference === 'cdc' && isCDCReferences(referenceData)) {
-                    centiles = referenceData.fenton || referenceData.cdc_infant || referenceData.cdc_child;
-                    // Fenton data is not available for CDC references currently so we skip it
-                    lowercentiles =
-                        midParentalHeightData.mid_parental_height_lower_centile_data[index].fenton ||
-                        midParentalHeightData.mid_parental_height_lower_centile_data[index].cdc_infant ||
-                        midParentalHeightData.mid_parental_height_lower_centile_data[index].cdc_child;
-                    uppercentiles =
-                        midParentalHeightData.mid_parental_height_upper_centile_data[index].fenton ||
-                        midParentalHeightData.mid_parental_height_upper_centile_data[index].cdc_infant ||
-                        midParentalHeightData.mid_parental_height_upper_centile_data[index].cdc_child;
-                } else {
-                    // Handle the case where the reference type does not match any known types
-                    throw new Error(`Unknown reference type: ${reference}`);
-                }
+            let centiles;
+            let lowercentiles;
+            let uppercentiles;
+            if (reference === 'uk-who' && isUKWHOReferences(referenceData)) {
+                centiles =
+                    referenceData.uk90_preterm ||
+                    referenceData.uk_who_infant ||
+                    referenceData.uk_who_child ||
+                    referenceData.uk90_child;
+                lowercentiles =
+                    lowerCentileReferenceData[index].uk90_preterm ||
+                    lowerCentileReferenceData[index].uk_who_infant ||
+                    lowerCentileReferenceData[index].uk_who_child ||
+                    lowerCentileReferenceData[index].uk90_child;
+                uppercentiles =
+                    upperCentileReferenceData[index].uk90_preterm ||
+                    upperCentileReferenceData[index].uk_who_infant ||
+                    upperCentileReferenceData[index].uk_who_child ||
+                    upperCentileReferenceData[index].uk90_child;
+            } else if (reference === 'cdc' && isCDCReferences(referenceData)) {
+                centiles = referenceData.fenton || referenceData.cdc_infant || referenceData.cdc_child;
+                // Fenton data is not available for CDC references currently so we skip it
+                lowercentiles =
+                    lowerCentileReferenceData[index].fenton ||
+                    lowerCentileReferenceData[index].cdc_infant ||
+                    lowerCentileReferenceData[index].cdc_child;
+                uppercentiles =
+                    upperCentileReferenceData[index].fenton ||
+                    upperCentileReferenceData[index].cdc_infant ||
+                    upperCentileReferenceData[index].cdc_child;
+            } else {
+                // Handle the case where the reference type does not match any known types
+                throw new Error(`Unknown reference type: ${reference}`);
+            }
 
-                const mpcData = sex === 'male' ? centiles.male.height : centiles.female.height;
-                const lowerMPCData = sex === 'male' ? lowercentiles.male.height : lowercentiles.female.height;
-                const upperMPCData = sex === 'male' ? uppercentiles.male.height : uppercentiles.female.height;
+            const mpcData = sex === 'male' ? (centiles?.male?.height ?? []) : (centiles?.female?.height ?? []);
+            const lowerMPCData =
+                sex === 'male' ? (lowercentiles?.male?.height ?? []) : (lowercentiles?.female?.height ?? []);
+            const upperMPCData =
+                sex === 'male' ? (uppercentiles?.male?.height ?? []) : (uppercentiles?.female?.height ?? []);
 
-                // filter the midparental centile data to render only 0.y either side of a given measurement.
-                // if no measurement provided, render it from 19.5 to 20 y
+            // filter the midparental centile data to render only 0.y either side of a given measurement.
+            // if no measurement provided, render it from 19.5 to 20 y
 
-                lowerMPCData.forEach((centile: ICentile) => {
-                    if (centile.data === null) {
-                        // skipping empty datasets like fenton
-                        return [];
-                    }
-                    const newData = centile.data.filter((measurementItem) => {
-                        if (measurementItem['x'] >= lowerLimit && measurementItem['x'] <= upperLimit) {
-                            return measurementItem;
-                        }
-                    });
-                    centile.data = newData;
-                    return centile;
-                });
-                mpcData.forEach((centile: ICentile) => {
-                    if (centile.data === null) {
-                        // skipping empty datasets like fenton
-                        return [];
-                    }
-                    const newData = centile.data.filter((measurementItem) => {
-                        if (measurementItem['x'] >= lowerLimit && measurementItem['x'] <= upperLimit) {
-                            return measurementItem;
-                        }
-                    });
-                    centile.data = newData;
-                    return centile;
-                });
-                upperMPCData.forEach((centile: ICentile) => {
-                    if (centile.data === null) {
-                        // skipping empty datasets like fenton
-                        return [];
-                    }
-                    const newData = centile.data.filter((measurementItem) => {
-                        if (measurementItem['x'] >= lowerLimit && measurementItem['x'] <= upperLimit) {
-                            return measurementItem;
-                        }
-                    });
-                    centile.data = newData;
-                    return centile;
-                });
+            const filteredLowerMPCData = filterCentilesByRange(lowerMPCData, lowerLimit, upperLimit);
+            const filteredMPCData = filterCentilesByRange(mpcData, lowerLimit, upperLimit);
+            const filteredUpperMPCData = filterCentilesByRange(upperMPCData, lowerLimit, upperLimit);
 
-                newReferenceObject.push({
-                    lowerParentalCentile: lowerMPCData,
-                    midParentalCentile: mpcData,
-                    upperParentalCentile: upperMPCData,
-                });
-            },
-        );
+            newReferenceObject.push({
+                lowerParentalCentile: filteredLowerMPCData,
+                midParentalCentile: filteredMPCData,
+                upperParentalCentile: filteredUpperMPCData,
+            });
+        });
 
         return newReferenceObject;
     } else {

--- a/src/functions/tooltips.ts
+++ b/src/functions/tooltips.ts
@@ -296,7 +296,7 @@ export function tooltipText(
                 // && age_error === null temporarily removed from if statement as error in api return object for EDD < observation_date
                 let corrected_gestational_age = '';
                 if (gestational_age) {
-                    corrected_gestational_age = `${gestational_age.corrected_gestationn_weeks}+${gestational_age.corrected_gestation_days} weeks`;
+                    corrected_gestational_age = `${gestational_age.corrected_gestation_weeks}+${gestational_age.corrected_gestation_days} weeks`;
                     returnStringList.push(`${calendar_age}`);
                     returnStringList.push(
                         `Corrected age: ${corrected_gestational_age} on ${formatted_observation_date} )`,


### PR DESCRIPTION
### Overview

issue #194 raised by @dmc-cambric thank you

#### Problem

The midparental height fails to render if the api call is made before the measurements are rendered. This is because the memoized filter of MPH centiles is destructive and so when the measurements api request returns to be rendered, the centiles have already been filtered and the arrays are empty at the ages of the measurements that subsequently return. 

The fix is to filter the full centiles each time

I have also added a test for this behaviour (MPH call before the measurements and vice versa)

There is an incidental bug fix I noticed where a typo in the preterm corrected gestational age tooltips was not rendering the gestation weeks.

fixes #194