### PR TITLE
Deploy Storybook to GitHub Pages (#204)

### DIFF
--- a/.github/workflows/deploy-storybook-pages.yml
+++ b/.github/workflows/deploy-storybook-pages.yml
@@ -1,0 +1,64 @@
+# Builds the Storybook static site and deploys it to GitHub Pages.
+# This gives the component library a stable, self-hosted Storybook URL
+# (https://rcpch.github.io/digital-growth-charts-react-component-library/)
+# as an alternative to the Chromatic-hosted permalink.
+#
+# Chromatic (see chromatic.yml) is retained for visual-regression testing;
+# this workflow is purely for publishing the browsable Storybook docs.
+
+name: Deploy Storybook to GitHub Pages
+
+on:
+  # Publish on every push to the default branch
+  push:
+    branches:
+      - live
+  # Allow manual runs from the Actions tab
+  workflow_dispatch:
+
+# Permissions required by the GitHub Pages deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the
+# run in-progress and latest queued. Do not cancel in-progress runs so a
+# deployment can complete.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Storybook
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22.x'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build Storybook
+        run: npm run build-storybook
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - name: Upload Storybook artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: storybook-static
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Closes #204

## What

Adds a GitHub Actions workflow (`.github/workflows/deploy-storybook-pages.yml`) that builds the static Storybook and publishes it to GitHub Pages on push to `live` (plus manual `workflow_dispatch`).

This gives the component library a stable, self-hosted Storybook URL:
`https://rcpch.github.io/digital-growth-charts-react-component-library/`

## Why

The documentation site currently links to the Chromatic-hosted Storybook permalink. A self-hosted GitHub Pages build provides a stable, project-owned URL that the docs site can iframe-embed, without depending on Chromatic's hosting.

Chromatic (see `chromatic.yml`) is **retained in parallel** for visual-regression testing - this workflow only publishes the browsable Storybook docs.

## Details

- Node 22, matching the repo's existing workflows.
- All actions SHA-pinned with semver comments per repo convention.
- Build verified locally: `npm ci` + `npm run build-storybook` produces `storybook-static/` (already gitignored).
- Storybook static builds use relative asset paths, so subpath project-pages hosting works without base-path config.

## Action required before merge

GitHub Pages must be enabled in repo settings: **Settings → Pages → Source = "GitHub Actions"**, otherwise the deploy job will fail.